### PR TITLE
Remove top-level array and add additional classes

### DIFF
--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -45,7 +45,7 @@
                             "dcterms:title",
                             "dcterms:description",
                             "dcterms:accessRights",
-                            "bv:dataOwner"
+                            "bv:affiliatedPersons"
                         ],
                         "properties": {
                             "dcterms:identifier": {
@@ -149,17 +149,40 @@
                                 "format": "date",
                                 "description": "Last modification date of the dataset (could be free text or date)."
                             },
-                            "bv:dataOwner": {
-                                "type": "string",
-                                "description": "The official owner of the data."
-                            },
-                            "bv:dataSteward": {
-                                "type": "string",
-                                "description": "Person or entity responsible for data stewardship."
-                            },
-                            "bv:dataCustodian": {
-                                "type": "string",
-                                "description": "Person or entity responsible for data custody."
+                            "bv:affiliatedPersons": {
+                                "type": "array",
+                                "description": "list of affiliated people with roles",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "name": {
+                                            "type": "string"
+                                        },
+                                        "email": {
+                                            "type": "string"
+                                        },
+                                        "role": {
+                                            "type": "string",
+                                            "description": "role",
+                                            "enum": [
+                                                "dataOwner",
+                                                "dataSteward",
+                                                "dataCustodian"
+                                            ]
+                                        }
+                                    },
+                                    "required": ["name", "email", "role"]
+                                },
+                                "minItems": 1,
+                                "contains": {
+                                    "type": "object",
+                                    "properties": {
+                                        "role": {
+                                            "const": "dataOwner"
+                                        }
+                                    },
+                                    "required": ["role"]
+                                }
                             },
                             "adms:status": {
                                 "type": "string",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -1,3 +1,4 @@
+
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://example.com/dataCatalogSchema.json",
@@ -355,7 +356,7 @@
                                 "items": {
                                     "type": "string"
                                 }
-                            }
+                            },
                             "dcat:distribution": {
                                 "type": "array",
                                 "description": "Distribution info describing how and where to access the dataset.",
@@ -848,7 +849,7 @@
                             "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the Catalog."
-                            }, ,
+                            },
                             "dcterms:title": {
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -591,7 +591,7 @@
         },
         "dataServices": {
             "type": "array",
-            "description": "Container for dcat:DataService"
+            "description": "Container for dcat:DataService",
             "items": {
                 "type": "object",
                 "description": "structure of DataService",
@@ -624,8 +624,12 @@
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the DataService",
-                        "required": ["dct:title", "dct:description", "dct:publisher", "dcat:contactPoint"],
+                        "required": ["dct:identifier", "dct:title", "dct:description", "dct:publisher", "dcat:contactPoint"],
                         "properties": {
+                            "dct:identifier": {
+                                "type": "string",
+                                "description": "Unique identifier for the DataService."
+                            },
                             "dct:title": {
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
@@ -729,6 +733,135 @@
                             "bv:comments": {
                                 "type": "string",
                                 "description": "Additional comments about the DataService."
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "catalogs": {
+            "type": "array",
+            "description": "container for dcat:Catalog",
+            "items": {
+                "type": "object",
+                "description": "structure of Catalog",
+                "required": ["metadata", "attributes"],
+                "properties": {
+                    "metadata": {
+                        "type": "object",
+                        "description": "Metadata about the catalog (last update date, user, image, etc.).",
+                        "required": [
+                            "lastChangeDate",
+                            "lastChangeUser"
+                        ],
+                        "properties": {
+                            "lastChangeDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Date/time when the series was last changed."
+                            },
+                            "lastChangeUser": {
+                                "type": "string",
+                                "description": "User or identifier who last updated the series."
+                            },
+                            "ImageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "URL linking to an image for this series."
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "description": "attributes for the Catalog",
+                        "required": ["dct:identifier", "dct:title", "dct:description", "dct:publisher", "dcat:contactPoint"],
+                        "properties": {
+                            "dct:identifier": {
+                                "type": "string",
+                                "description": "Unique identifier for the Catalog."
+                            }, ,
+                            "dct:title": {
+                                "type": "object",
+                                "description": "Title for the series in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
+                                    },
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "dct:description": {
+                                "type": "object",
+                                "description": "Description for the series in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
+                                    },
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "dct:publisher": {
+                                "type": "string",
+                                "description": "Publisher or organization responsible for the series."
+                            },
+                            "dcat:contactPoint": {
+                                "type": "object",
+                                "description": "Contact information for inquiries.",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "email": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["name", "email"]
+                            },
+                            "dct:accessRights": {
+                                "type": "string",
+                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+                                "enum": [
+                                    "CONFIDENTIAL",
+                                    "NON_PUBLIC",
+                                    "PUBLIC",
+                                    "RESTRICTED",
+                                    "SENSITIVE"
+                                ]
+                            },
+                            "foaf:homepage": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "homepage for the catalog"
+                            },
+                            "dcat:dataset": {
+                                "type": "array",
+                                "description": "IDs of the datasets in the catalog",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "dcat:service": {
+                                "type": "array",
+                                "description": "IDs of the dataServices in the catalog",
+                                "items": {
+                                    "type": "string"
+                                }
                             }
                         }
                     }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -588,6 +588,152 @@
                     }
                 }
             }
+        },
+        "dataServices": {
+            "type": "array",
+            "description": "Container for dcat:DataService"
+            "items": {
+                "type": "object",
+                "description": "structure of DataService",
+                "required": ["metadata", "attributes"],
+                "properties": {
+                    "metadata": {
+                        "type": "object",
+                        "description": "Metadata about the dataset series (last update date, user, image, etc.).",
+                        "required": [
+                            "lastChangeDate",
+                            "lastChangeUser"
+                        ],
+                        "properties": {
+                            "lastChangeDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Date/time when the series was last changed."
+                            },
+                            "lastChangeUser": {
+                                "type": "string",
+                                "description": "User or identifier who last updated the series."
+                            },
+                            "ImageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "URL linking to an image for this series."
+                            }
+                        }
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "description": "attributes for the DataService",
+                        "required": ["dct:title", "dct:description", "dct:publisher", "dcat:contactPoint"],
+                        "properties": {
+                            "dct:title": {
+                                "type": "object",
+                                "description": "Title for the series in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
+                                    },
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "dct:description": {
+                                "type": "object",
+                                "description": "Description for the series in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
+                                    },
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "dct:publisher": {
+                                "type": "string",
+                                "description": "Publisher or organization responsible for the series."
+                            },
+                            "dcat:contactPoint": {
+                                "type": "object",
+                                "description": "Contact information for inquiries.",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "email": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["name", "email"]
+                            },
+                            "dct:accessRights": {
+                                "type": "string",
+                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+                                "enum": [
+                                    "CONFIDENTIAL",
+                                    "NON_PUBLIC",
+                                    "PUBLIC",
+                                    "RESTRICTED",
+                                    "SENSITIVE"
+                                ]
+                            },
+                            "dcat:endopointURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "URL of the service."
+                            },
+                            "adms:status": {
+                                "type": "string",
+                                "description": "Current status of the dataset (sample enumeration).",
+                                "enum": [
+                                    "workInProgress",
+                                    "validated",
+                                    "published",
+                                    "deleted",
+                                    "archived"
+                                ]
+                            },
+                            "dcat:servesDataset": {
+                                "type": "array",
+                                "description": "IDs of the datasets served",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "dcat:endpointDescription": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "URL of documentation."
+                            },
+                            "foaf:page": {
+                                "type": "array",
+                                "description": "Any related page or resource.",
+                                "items": {
+                                    "type": ["string", "null"],
+                                    "format": "uri"
+                                }
+                            },
+                            "bv:comments": {
+                                "type": "string",
+                                "description": "Additional comments about the DataService."
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -41,18 +41,18 @@
                         "type": "object",
                         "description": "Descriptive attributes for the dataset entry.",
                         "required": [
-                            "dct:identifier",
-                            "dct:title",
-                            "dct:description",
-                            "dct:accessRights",
+                            "dcterms:identifier",
+                            "dcterms:title",
+                            "dcterms:description",
+                            "dcterms:accessRights",
                             "bv:dataOwner"
                         ],
                         "properties": {
-                            "dct:identifier": {
+                            "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the dataset."
                             },
-                            "dct:title": {
+                            "dcterms:title": {
                                 "type": "object",
                                 "description": "Title of the dataset in multiple languages.",
                                 "properties": {
@@ -71,7 +71,7 @@
                                 },
                                 "required": ["de", "fr"]
                             },
-                            "dct:description": {
+                            "dcterms:description": {
                                 "type": "object",
                                 "description": "Description of the dataset in multiple languages.",
                                 "properties": {
@@ -90,7 +90,7 @@
                                 },
                                 "required": ["de", "fr"]
                             },
-                            "dct:accessRights": {
+                            "dcterms:accessRights": {
                                 "type": "string",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [
@@ -101,7 +101,7 @@
                                     "SENSITIVE"
                                 ]
                             },
-                            "dct:publisher": {
+                            "dcterms:publisher": {
                                 "type": "string",
                                 "description": "Name of the publishing entity or organization."
                             },
@@ -118,7 +118,7 @@
                                 },
                                 "required": ["name", "email"]
                             },
-                            "dct:issued": {
+                            "dcterms:issued": {
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "description": "When the dataset was formally issued (YYYY-MM-DD or empty)."
@@ -130,7 +130,7 @@
                                     "type": "string"
                                 }
                             },
-                            "dct:accrualPeriodicity": {
+                            "dcterms:accrualPeriodicity": {
                                 "type": "string",
                                 "description": "Frequency with which dataset is updated (e.g., 'Annual').",
                                 "enum": [
@@ -144,7 +144,7 @@
                                     "AS_NEEDED"
                                 ]
                             },
-                            "dct:modified": {
+                            "dcterms:modified": {
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "description": "Last modification date of the dataset (could be free text or date)."
@@ -212,7 +212,7 @@
                                     "opendata.swiss": {
                                         "type": "boolean"
                                     },
-                                    "dct:identifier": {
+                                    "dcterms:identifier": {
                                         "type": "string",
                                         "description": "Identifier for the OGD publication"
                                     },
@@ -241,11 +241,11 @@
                                 "format": "uri",
                                 "description": "Landing page or homepage for the dataset."
                             },
-                            "dct:spatial": {
+                            "dcterms:spatial": {
                                 "type": "string",
                                 "description": "Spatial/geographical coverage."
                             },
-                            "dct:temporal": {
+                            "dcterms:temporal": {
                                 "type": "string",
                                 "description": "Temporal coverage of the dataset."
                             },
@@ -308,6 +308,13 @@
                                 "type": "string",
                                 "description": "Reference to the series this dataset belongs to."
                             },
+                            "dcterms:replaces": {
+                                "type": "array",
+                                "description": "ID of datasets replaced by this one",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
                             "dcat:distribution": {
                                 "type": "array",
                                 "description": "Distribution info describing how and where to access the dataset.",
@@ -341,13 +348,13 @@
                                         "attributes": {
                                             "type": "object",
                                             "required": [
-                                                "dct:identifier",
+                                                "dcterms:identifier",
                                                 "dcat:accessURL",
-                                                "dct:title",
-                                                "dct:description"
+                                                "dcterms:title",
+                                                "dcterms:description"
                                             ],
                                             "properties": {
-                                                "dct:identifier": {
+                                                "dcterms:identifier": {
                                                     "type": "string",
                                                     "description": "Identifier for this distribution."
                                                 },
@@ -367,11 +374,11 @@
                                                         "archived"
                                                     ]
                                                 },
-                                                "dct:format": {
+                                                "dcterms:format": {
                                                     "type": "string",
                                                     "description": "File format (e.g., CSV, JSON)."
                                                 },
-                                                "dct:modified": {
+                                                "dcterms:modified": {
                                                     "type": ["string", "null"],
                                                     "format": "date-time",
                                                     "description": "When the distribution file was last modified."
@@ -381,7 +388,7 @@
                                                     "format": "uri",
                                                     "description": "Download URL of the distribution file."
                                                 },
-                                                "dct:title": {
+                                                "dcterms:title": {
                                                     "type": "object",
                                                     "description": "Title for the distribution, in multiple languages.",
                                                     "properties": {
@@ -399,7 +406,7 @@
                                                         }
                                                     }
                                                 },
-                                                "dct:description": {
+                                                "dcterms:description": {
                                                     "type": "object",
                                                     "description": "Description for the distribution, in multiple languages.",
                                                     "properties": {
@@ -417,11 +424,11 @@
                                                         }
                                                     }
                                                 },
-                                                "dct:conformsTo": {
+                                                "dcterms:conformsTo": {
                                                     "type": "string",
                                                     "description": "Reference to a standard or specification the distribution conforms to."
                                                 },
-                                                "dct:licence": {
+                                                "dcterms:licence": {
                                                     "type": "string",
                                                     "description": "License under which this distribution is released.",
                                                     "enum": [
@@ -486,15 +493,17 @@
                         "type": "object",
                         "description": "Descriptive attributes for the dataset series.",
                         "required": [
-                            "dct:identifier",
-                            "dct:title"
+                            "dcterms:identifier",
+                            "dcterms:title",
+                            "bv:classification",
+                            "bv:personalData"
                         ],
                         "properties": {
-                            "dct:identifier": {
+                            "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the dataset series."
                             },
-                            "dct:title": {
+                            "dcterms:title": {
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
@@ -512,7 +521,7 @@
                                     }
                                 }
                             },
-                            "dct:description": {
+                            "dcterms:description": {
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
@@ -543,7 +552,7 @@
                                 },
                                 "required": ["name", "email"]
                             },
-                            "dct:publisher": {
+                            "dcterms:publisher": {
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the series."
                             },
@@ -583,6 +592,25 @@
                                 "items": {
                                     "type": "string"
                                 }
+                            },
+                            "bv:classification": {
+                                "type": "string",
+                                "description": "Classification level of the dataset (sample enumeration).",
+                                "enum": [
+                                    "none",
+                                    "internal",
+                                    "confidential",
+                                    "secret"
+                                ]
+                            },
+                            "bv:personalData": {
+                                "type": "string",
+                                "description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
+                                "enum": [
+                                    "none",
+                                    "personalData",
+                                    "sensitivePersonalData"
+                                ]
                             }
                         }
                     }
@@ -624,13 +652,13 @@
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the DataService",
-                        "required": ["dct:identifier", "dct:title", "dct:description", "dct:publisher", "dcat:contactPoint"],
+                        "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
                         "properties": {
-                            "dct:identifier": {
+                            "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the DataService."
                             },
-                            "dct:title": {
+                            "dcterms:title": {
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
@@ -648,7 +676,7 @@
                                     }
                                 }
                             },
-                            "dct:description": {
+                            "dcterms:description": {
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
@@ -666,7 +694,7 @@
                                     }
                                 }
                             },
-                            "dct:publisher": {
+                            "dcterms:publisher": {
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the series."
                             },
@@ -683,7 +711,7 @@
                                 },
                                 "required": ["name", "email"]
                             },
-                            "dct:accessRights": {
+                            "dcterms:accessRights": {
                                 "type": "string",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [
@@ -774,13 +802,13 @@
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the Catalog",
-                        "required": ["dct:identifier", "dct:title", "dct:description", "dct:publisher", "dcat:contactPoint"],
+                        "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
                         "properties": {
-                            "dct:identifier": {
+                            "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the Catalog."
                             }, ,
-                            "dct:title": {
+                            "dcterms:title": {
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
@@ -798,7 +826,7 @@
                                     }
                                 }
                             },
-                            "dct:description": {
+                            "dcterms:description": {
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
@@ -816,7 +844,7 @@
                                     }
                                 }
                             },
-                            "dct:publisher": {
+                            "dcterms:publisher": {
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the series."
                             },
@@ -833,7 +861,7 @@
                                 },
                                 "required": ["name", "email"]
                             },
-                            "dct:accessRights": {
+                            "dcterms:accessRights": {
                                 "type": "string",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -205,11 +205,11 @@
                                 "type": "boolean",
                                 "description": "Indicates if this dataset has archival value."
                             },
-                            "bv:ogdPublication": {
+                            "bv:opendata.swiss": {
                                 "type": "object",
                                 "description": "Reference to the Open Government Data publication ID.",
                                 "properties": {
-                                    "opendata.swiss": {
+                                    "bv:mustBePublished": {
                                         "type": "boolean"
                                     },
                                     "dcterms:identifier": {
@@ -223,6 +223,24 @@
                                     }
                                 }
                             },
+							"bv:i14y": {
+								"type": "object",
+                                "description": "Reference to the I14Y publication ID.",
+                                "properties": {
+                                    "bv:mustBePublished": {
+                                        "type": "boolean"
+                                    },
+                                    "dcterms:identifier": {
+                                        "type": "string",
+                                        "description": "Identifier for the I14Y publication"
+                                    },
+                                    "dcat:accessURL": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "URL on I14Y"
+                                    }
+                                }
+							},
                             "dcat:themeTaxonomy": {
                                 "type": "array",
                                 "description": "Reference or URL to a theme taxonomy classification.",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -3,318 +3,316 @@
     "$id": "https://example.com/dataCatalogSchema.json",
     "title": "Data Catalog Schema",
     "description": "JSON Schema for validating data catalog entries, including datasets and datasetSeries.",
-    "type": "array",
-    "items": {
-        "type": "object",
-        "description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
-        "required": ["dataset"],
-        "properties": {
-            "dataset": {
+    "type": "object",
+    "properties": {
+        "datasets": {
+            "type": "array",
+            "description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
+            "items": {
                 "type": "object",
-                "description": "Container for individual datasets keyed by an identifier such as 'BFE-DS-0001'.",
-                "additionalProperties": {
-                    "type": "object",
-                    "description": "Structure of each dataset entry. Keys are dataset IDs (e.g. 'BFE-DS-0001').",
-                    "required": ["metadata", "attributes"],
-                    "properties": {
-                        "metadata": {
-                            "type": "object",
-                            "description": "Metadata about the dataset, including last change date, user, etc.",
-                            "required": [
-                                "lastChangeDate",
-                                "lastChangeUser"
-                            ],
-                            "properties": {
-                                "lastChangeDate": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "description": "Date/time when the dataset was last updated."
-                                },
-                                "lastChangeUser": {
-                                    "type": "string",
-                                    "description": "Name or identifier of the user who performed the last update."
-                                },
-                                "ImageURL": {
-                                    "type": ["string", "null"],
-                                    "format": "uri",
-                                    "description": "URL linking to an image for this dataset."
-                                }
+                "description": "Structure of each dataset entry. Keys are dataset IDs (e.g. 'BFE-DS-0001').",
+                "required": ["metadata", "attributes"],
+                "properties": {
+                    "metadata": {
+                        "type": "object",
+                        "description": "Metadata about the dataset, including last change date, user, etc.",
+                        "required": [
+                            "lastChangeDate",
+                            "lastChangeUser"
+                        ],
+                        "properties": {
+                            "lastChangeDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Date/time when the dataset was last updated."
+                            },
+                            "lastChangeUser": {
+                                "type": "string",
+                                "description": "Name or identifier of the user who performed the last update."
+                            },
+                            "ImageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "URL linking to an image for this dataset."
                             }
-                        },
-                        "attributes": {
-                            "type": "object",
-                            "description": "Descriptive attributes for the dataset entry.",
-                            "required": [
-                                "dct:identifier",
-                                "dct:title",
-                                "dct:description",
-                                "dct:accessRights",
-                                "bv:dataOwner"
-                            ],
-                            "properties": {
-                                "dct:identifier": {
-                                    "type": "string",
-                                    "description": "Unique identifier for the dataset."
-                                },
-                                "dct:title": {
-                                    "type": "object",
-                                    "description": "Title of the dataset in multiple languages.",
-                                    "properties": {
-                                        "de": {
-                                            "type": "string"
-                                        },
-                                        "fr": {
-                                            "type": "string"
-                                        },
-                                        "it": {
-                                            "type": "string"
-                                        },
-                                        "en": {
-                                            "type": "string"
-                                        }
+                        }
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "description": "Descriptive attributes for the dataset entry.",
+                        "required": [
+                            "dct:identifier",
+                            "dct:title",
+                            "dct:description",
+                            "dct:accessRights",
+                            "bv:dataOwner"
+                        ],
+                        "properties": {
+                            "dct:identifier": {
+                                "type": "string",
+                                "description": "Unique identifier for the dataset."
+                            },
+                            "dct:title": {
+                                "type": "object",
+                                "description": "Title of the dataset in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
                                     },
-                                    "required": ["de", "fr"]
-                                },
-                                "dct:description": {
-                                    "type": "object",
-                                    "description": "Description of the dataset in multiple languages.",
-                                    "properties": {
-                                        "de": {
-                                            "type": "string"
-                                        },
-                                        "fr": {
-                                            "type": "string"
-                                        },
-                                        "it": {
-                                            "type": "string"
-                                        },
-                                        "en": {
-                                            "type": "string"
-                                        }
+                                    "fr": {
+                                        "type": "string"
                                     },
-                                    "required": ["de", "fr"]
-                                },
-                                "dct:accessRights": {
-                                    "type": "string",
-                                    "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
-                                    "enum": [
-                                        "CONFIDENTIAL",
-                                        "NON_PUBLIC",
-                                        "PUBLIC",
-                                        "RESTRICTED",
-                                        "SENSITIVE"
-                                    ]
-                                },
-                                "dct:publisher": {
-                                    "type": "string",
-                                    "description": "Name of the publishing entity or organization."
-                                },
-                                "dcat:contactPoint": {
-                                    "type": "object",
-                                    "description": "Contact information for inquiries.",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "email": {
-                                            "type": "string"
-                                        }
+                                    "it": {
+                                        "type": "string"
                                     },
-                                    "required": ["name", "email"]
-                                },
-                                "dct:issued": {
-                                    "type": ["string", "null"],
-                                    "format": "date",
-                                    "description": "When the dataset was formally issued (YYYY-MM-DD or empty)."
-                                },
-                                "dcat:keyword": {
-                                    "type": "array",
-                                    "description": "Keywords describing the dataset.",
-                                    "items": {
+                                    "en": {
                                         "type": "string"
                                     }
                                 },
-                                "dct:accrualPeriodicity": {
-                                    "type": "string",
-                                    "description": "Frequency with which dataset is updated (e.g., 'Annual').",
-                                    "enum": [
-                                        "OTHER",
-                                        "HOURLY",
-                                        "UNKNOWN",
-                                        "QUARTERLY",
-                                        "NEVER",
-                                        "ANNUAL",
-                                        "DAILY",
-                                        "AS_NEEDED"
-                                    ]
-                                },
-                                "dct:modified": {
-                                    "type": ["string", "null"],
-                                    "format": "date",
-                                    "description": "Last modification date of the dataset (could be free text or date)."
-                                },
-                                "bv:dataOwner": {
-                                    "type": "string",
-                                    "description": "The official owner of the data."
-                                },
-                                "bv:dataSteward": {
-                                    "type": "string",
-                                    "description": "Person or entity responsible for data stewardship."
-                                },
-                                "bv:dataCustodian": {
-                                    "type": "string",
-                                    "description": "Person or entity responsible for data custody."
-                                },
-                                "adms:status": {
-                                    "type": "string",
-                                    "description": "Current status of the dataset (sample enumeration).",
-                                    "enum": [
-                                        "workInProgress",
-                                        "validated",
-                                        "published",
-                                        "deleted",
-                                        "archived"
-                                    ]
-                                },
-                                "bv:classification": {
-                                    "type": "string",
-                                    "description": "Classification level of the dataset (sample enumeration).",
-                                    "enum": [
-                                        "none",
-                                        "internal",
-                                        "confidential",
-                                        "secret"
-                                    ]
-                                },
-                                "bv:personalData": {
-                                    "type": "string",
-                                    "description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
-                                    "enum": [
-                                        "none",
-                                        "personalData",
-                                        "sensitivePersonalData"
-                                    ]
-                                },
-                                "bv:typeOfData": {
-                                    "type": "string",
-                                    "description": "Specifies the type of data (structured, unstructured, etc.).",
-                                    "enum": [
-                                        "thematicData",
-                                        "referenceData",
-                                        "masterData",
-                                        "unstructuredData"
-                                    ]
-                                },
-                                "bv:archivalValue": {
-                                    "type": "boolean",
-                                    "description": "Indicates if this dataset has archival value."
-                                },
-                                "bv:ogdPublication": {
-                                    "type": "object",
-                                    "description": "Reference to the Open Government Data publication ID.",
-                                    "properties": {
-                                        "opendata.swiss": {
-                                            "type": "boolean"
-                                        },
-					"dct:identifier": {
-                                            "type": "string",
-                                            "description": "Identifier for the OGD publication"
-                                        },
-                                        "dcat:accessURL": {
-                                            "type": "string",
-                                            "format": "uri",
-                                            "description": "URL on opendata.swiss"
-                                        }
+                                "required": ["de", "fr"]
+                            },
+                            "dct:description": {
+                                "type": "object",
+                                "description": "Description of the dataset in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
+                                    },
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
                                     }
                                 },
-                                "dcat:themeTaxonomy": {
-                                    "type": "array",
-                                    "description": "Reference or URL to a theme taxonomy classification.",
-                                    "items": {
+                                "required": ["de", "fr"]
+                            },
+                            "dct:accessRights": {
+                                "type": "string",
+                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+                                "enum": [
+                                    "CONFIDENTIAL",
+                                    "NON_PUBLIC",
+                                    "PUBLIC",
+                                    "RESTRICTED",
+                                    "SENSITIVE"
+                                ]
+                            },
+                            "dct:publisher": {
+                                "type": "string",
+                                "description": "Name of the publishing entity or organization."
+                            },
+                            "dcat:contactPoint": {
+                                "type": "object",
+                                "description": "Contact information for inquiries.",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "email": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["name", "email"]
+                            },
+                            "dct:issued": {
+                                "type": ["string", "null"],
+                                "format": "date",
+                                "description": "When the dataset was formally issued (YYYY-MM-DD or empty)."
+                            },
+                            "dcat:keyword": {
+                                "type": "array",
+                                "description": "Keywords describing the dataset.",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "dct:accrualPeriodicity": {
+                                "type": "string",
+                                "description": "Frequency with which dataset is updated (e.g., 'Annual').",
+                                "enum": [
+                                    "OTHER",
+                                    "HOURLY",
+                                    "UNKNOWN",
+                                    "QUARTERLY",
+                                    "NEVER",
+                                    "ANNUAL",
+                                    "DAILY",
+                                    "AS_NEEDED"
+                                ]
+                            },
+                            "dct:modified": {
+                                "type": ["string", "null"],
+                                "format": "date",
+                                "description": "Last modification date of the dataset (could be free text or date)."
+                            },
+                            "bv:dataOwner": {
+                                "type": "string",
+                                "description": "The official owner of the data."
+                            },
+                            "bv:dataSteward": {
+                                "type": "string",
+                                "description": "Person or entity responsible for data stewardship."
+                            },
+                            "bv:dataCustodian": {
+                                "type": "string",
+                                "description": "Person or entity responsible for data custody."
+                            },
+                            "adms:status": {
+                                "type": "string",
+                                "description": "Current status of the dataset (sample enumeration).",
+                                "enum": [
+                                    "workInProgress",
+                                    "validated",
+                                    "published",
+                                    "deleted",
+                                    "archived"
+                                ]
+                            },
+                            "bv:classification": {
+                                "type": "string",
+                                "description": "Classification level of the dataset (sample enumeration).",
+                                "enum": [
+                                    "none",
+                                    "internal",
+                                    "confidential",
+                                    "secret"
+                                ]
+                            },
+                            "bv:personalData": {
+                                "type": "string",
+                                "description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
+                                "enum": [
+                                    "none",
+                                    "personalData",
+                                    "sensitivePersonalData"
+                                ]
+                            },
+                            "bv:typeOfData": {
+                                "type": "string",
+                                "description": "Specifies the type of data (structured, unstructured, etc.).",
+                                "enum": [
+                                    "thematicData",
+                                    "referenceData",
+                                    "masterData",
+                                    "unstructuredData"
+                                ]
+                            },
+                            "bv:archivalValue": {
+                                "type": "boolean",
+                                "description": "Indicates if this dataset has archival value."
+                            },
+                            "bv:ogdPublication": {
+                                "type": "object",
+                                "description": "Reference to the Open Government Data publication ID.",
+                                "properties": {
+                                    "opendata.swiss": {
+                                        "type": "boolean"
+                                    },
+                                    "dct:identifier": {
                                         "type": "string",
-                                        "enum": [
-                                            "populationAndSociety",
-                                            "agricultureFisheriesForestryFood",
-                                            "internationalTopics",
-                                            "environment"
-                                        ]
-                                    }
-                                },
-                                "dcat:landingPage": {
-                                    "type": ["string", "null"],
-                                    "format": "uri",
-                                    "description": "Landing page or homepage for the dataset."
-                                },
-                                "dct:spatial": {
-                                    "type": "string",
-                                    "description": "Spatial/geographical coverage."
-                                },
-                                "dct:temporal": {
-                                    "type": "string",
-                                    "description": "Temporal coverage of the dataset."
-                                },
-                                "bv:legalBasis": {
-                                    "type": "array",
-                                    "items": {
-                                        "type": ["string", "null"],
-                                        "format": "uri"
+                                        "description": "Identifier for the OGD publication"
                                     },
-                                    "description": "Legal basis for the dataset (as URI)."
-                                },
-                                "bv:businessProcess": {
-                                    "type": "array",
-                                    "description": "Related business process or context.",
-									"items": {
-                                        "type": "string"
+                                    "dcat:accessURL": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "URL on opendata.swiss"
                                     }
-                                },
-                                "bv:retentionPeriod": {
-                                    "type": "integer",
-                                    "description": "Retention period for the dataset."
-                                },
-                                "dcat:catalog": {
+                                }
+                            },
+                            "dcat:themeTaxonomy": {
+                                "type": "array",
+                                "description": "Reference or URL to a theme taxonomy classification.",
+                                "items": {
                                     "type": "string",
-                                    "description": "Indicates which catalog this dataset belongs to."
-                                },
-                                "prov:wasDerivedFrom": {
-                                    "type": "array",
-                                    "description": "Source from which this dataset was derived.",
-				    "items": {
-                                        "type": "string"
-                                    }
-                                },
-                                "bv:geoIdentifier": {
-                                    "type": "string",
-                                    "description": "Geographical identifier (e.g., BFS numbers)."
-                                },
-                                "foaf:page": {
-                                    "type": "array",
-                                    "description": "Any related page or resource.",
-				    "items": {
-                                        "type": ["string", "null"],
-					"format": "uri"
-                                    }
-                                },
-                                "bv:comments": {
-                                    "type": "string",
-                                    "description": "Additional comments about the dataset."
-                                },
-                                "bv:abrogation": {
+                                    "enum": [
+                                        "populationAndSociety",
+                                        "agricultureFisheriesForestryFood",
+                                        "internationalTopics",
+                                        "environment"
+                                    ]
+                                }
+                            },
+                            "dcat:landingPage": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "Landing page or homepage for the dataset."
+                            },
+                            "dct:spatial": {
+                                "type": "string",
+                                "description": "Spatial/geographical coverage."
+                            },
+                            "dct:temporal": {
+                                "type": "string",
+                                "description": "Temporal coverage of the dataset."
+                            },
+                            "bv:legalBasis": {
+                                "type": "array",
+                                "items": {
                                     "type": ["string", "null"],
-                                    "format": "date",
-                                    "description": "Indicates if the dataset was abrogated or replaced."
+                                    "format": "uri"
                                 },
-                                "bv:itSystem": {
-                                    "type": "string",
-                                    "description": "Name of the IT system managing this dataset."
-                                },
-                                "dcat:inSeries": {
-                                    "type": "string",
-                                    "description": "Reference to the series this dataset belongs to."
-                                },
-                                "distribution": {
+                                "description": "Legal basis for the dataset (as URI)."
+                            },
+                            "bv:businessProcess": {
+                                "type": "array",
+                                "description": "Related business process or context.",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "bv:retentionPeriod": {
+                                "type": "integer",
+                                "description": "Retention period for the dataset."
+                            },
+                            "dcat:catalog": {
+                                "type": "string",
+                                "description": "Indicates which catalog this dataset belongs to."
+                            },
+                            "prov:wasDerivedFrom": {
+                                "type": "array",
+                                "description": "Source from which this dataset was derived.",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "bv:geoIdentifier": {
+                                "type": "string",
+                                "description": "Geographical identifier (e.g., BFS numbers)."
+                            },
+                            "foaf:page": {
+                                "type": "array",
+                                "description": "Any related page or resource.",
+                                "items": {
+                                    "type": ["string", "null"],
+                                    "format": "uri"
+                                }
+                            },
+                            "bv:comments": {
+                                "type": "string",
+                                "description": "Additional comments about the dataset."
+                            },
+                            "bv:abrogation": {
+                                "type": ["string", "null"],
+                                "format": "date",
+                                "description": "Indicates if the dataset was abrogated or replaced."
+                            },
+                            "bv:itSystem": {
+                                "type": "string",
+                                "description": "Name of the IT system managing this dataset."
+                            },
+                            "dcat:inSeries": {
+                                "type": "string",
+                                "description": "Reference to the series this dataset belongs to."
+                            },
+                            "dcat:distribution": {
+                                "type": "array",
+                                "description": "Distribution info describing how and where to access the dataset.",
+                                "items": {
                                     "type": "object",
-                                    "description": "Distribution info describing how and where to access the dataset.",
                                     "required": ["metadata", "attributes"],
                                     "properties": {
                                         "metadata": {
@@ -450,140 +448,140 @@
                         }
                     }
                 }
-            },
-            "datasetSeries": {
+            }
+        },
+        "datasetSeries": {
+            "type": "array",
+            "description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
+            "items": {
                 "type": "object",
-                "description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
-                "additionalProperties": {
-                    "type": "object",
-                    "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01').",
-                    "required": ["metadata", "attributes"],
-                    "properties": {
-                        "metadata": {
-                            "type": "object",
-                            "description": "Metadata about the dataset series (last update date, user, image, etc.).",
-                            "required": [
-                                "lastChangeDate",
-                                "lastChangeUser"
-                            ],
-                            "properties": {
-                                "lastChangeDate": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "description": "Date/time when the series was last changed."
-                                },
-                                "lastChangeUser": {
-                                    "type": "string",
-                                    "description": "User or identifier who last updated the series."
-                                },
-                                "ImageURL": {
-                                    "type": ["string", "null"],
-                                    "format": "uri",
-                                    "description": "URL linking to an image for this series."
-                                }
+                "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01').",
+                "required": ["metadata", "attributes"],
+                "properties": {
+                    "metadata": {
+                        "type": "object",
+                        "description": "Metadata about the dataset series (last update date, user, image, etc.).",
+                        "required": [
+                            "lastChangeDate",
+                            "lastChangeUser"
+                        ],
+                        "properties": {
+                            "lastChangeDate": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": "Date/time when the series was last changed."
+                            },
+                            "lastChangeUser": {
+                                "type": "string",
+                                "description": "User or identifier who last updated the series."
+                            },
+                            "ImageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "description": "URL linking to an image for this series."
                             }
-                        },
-                        "attributes": {
-                            "type": "object",
-                            "description": "Descriptive attributes for the dataset series.",
-                            "required": [
-                                "dct:identifier",
-                                "dct:title"
-                            ],
-                            "properties": {
-                                "dct:identifier": {
-                                    "type": "string",
-                                    "description": "Unique identifier for the dataset series."
-                                },
-                                "dct:title": {
-                                    "type": "object",
-                                    "description": "Title for the series in multiple languages.",
-                                    "properties": {
-                                        "de": {
-                                            "type": "string"
-                                        },
-                                        "fr": {
-                                            "type": "string"
-                                        },
-                                        "it": {
-                                            "type": "string"
-                                        },
-                                        "en": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "dct:description": {
-                                    "type": "object",
-                                    "description": "Description for the series in multiple languages.",
-                                    "properties": {
-                                        "de": {
-                                            "type": "string"
-                                        },
-                                        "fr": {
-                                            "type": "string"
-                                        },
-                                        "it": {
-                                            "type": "string"
-                                        },
-                                        "en": {
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "dcat:contactPoint": {
-                                    "type": "object",
-                                    "description": "Contact information for inquiries.",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "email": {
-                                            "type": "string"
-                                        }
+                        }
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "description": "Descriptive attributes for the dataset series.",
+                        "required": [
+                            "dct:identifier",
+                            "dct:title"
+                        ],
+                        "properties": {
+                            "dct:identifier": {
+                                "type": "string",
+                                "description": "Unique identifier for the dataset series."
+                            },
+                            "dct:title": {
+                                "type": "object",
+                                "description": "Title for the series in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
                                     },
-                                    "required": ["name", "email"]
-                                },
-                                "dct:publisher": {
-                                    "type": "string",
-                                    "description": "Publisher or organization responsible for the series."
-                                },
-                                "adms:status": {
-                                    "type": "string",
-                                    "description": "Current status of the dataset (sample enumeration).",
-                                    "enum": [
-                                        "workInProgress",
-                                        "validated",
-                                        "published",
-                                        "deleted",
-                                        "archived"
-                                    ]
-                                },
-                                "dcat:dataset": {
-                                    "type": "array",
-                                    "description": "Indicates which dataset(s) this series serves or is related to.",
-                                    "items": {
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "dct:description": {
+                                "type": "object",
+                                "description": "Description for the series in multiple languages.",
+                                "properties": {
+                                    "de": {
+                                        "type": "string"
+                                    },
+                                    "fr": {
+                                        "type": "string"
+                                    },
+                                    "it": {
+                                        "type": "string"
+                                    },
+                                    "en": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "dcat:contactPoint": {
+                                "type": "object",
+                                "description": "Contact information for inquiries.",
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "email": {
                                         "type": "string"
                                     }
                                 },
-                                "foaf:page": {
-                                    "type": "array",
-                                    "description": "Any related page or resource.",
-				    "items": {
-                                        "type": ["string", "null"],
-					"format": "uri"
-                                    }
-                                },
-                                "bv:comment": {
-                                    "type": "string",
-                                    "description": "Additional comments or notes about the series."
-                                },
-                                "dcat:keyword": {
-                                    "type": "array",
-                                    "description": "Keywords describing the dataset Serie.",
-                                    "items": {
-                                        "type": "string"
-                                    }
+                                "required": ["name", "email"]
+                            },
+                            "dct:publisher": {
+                                "type": "string",
+                                "description": "Publisher or organization responsible for the series."
+                            },
+                            "adms:status": {
+                                "type": "string",
+                                "description": "Current status of the dataset (sample enumeration).",
+                                "enum": [
+                                    "workInProgress",
+                                    "validated",
+                                    "published",
+                                    "deleted",
+                                    "archived"
+                                ]
+                            },
+                            "dcat:dataset": {
+                                "type": "array",
+                                "description": "Indicates which dataset(s) this series serves or is related to.",
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "foaf:page": {
+                                "type": "array",
+                                "description": "Any related page or resource.",
+                                "items": {
+                                    "type": ["string", "null"],
+                                    "format": "uri"
+                                }
+                            },
+                            "bv:comment": {
+                                "type": "string",
+                                "description": "Additional comments or notes about the series."
+                            },
+                            "dcat:keyword": {
+                                "type": "array",
+                                "description": "Keywords describing the dataset Serie.",
+                                "items": {
+                                    "type": "string"
                                 }
                             }
                         }


### PR DESCRIPTION
This pull request:

- refactors the JSON schema and removes the top-level array. "datasets" and "datasetSeries" are now arrays within the main object
- adds the dcat:DataService and dcat:Catalog classes as arrays at the same level as the Datasets and DatasetSeries ones
- renames a lot of dct to dcterms in order to comply with the DCAT voc
- adds security info to DatasetSeries