### PR TITLE
Schema update

### DIFF
--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -1,961 +1,1003 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://example.com/dataCatalogSchema.json",
-    "title": "Data Catalog Schema",
-    "description": "JSON Schema for validating data catalog entries, including datasets and datasetSeries.",
-    "type": "object",
-    "properties": {
-        "datasets": {
-            "type": "array",
-            "additionalProperties": false,
-            "description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
-            "items": {
-                "type": "object",
-                "title": "Dataset metadata",
-                "description": "One item (i.e., one datset metadata) in the collection of datasets.",
-                "required": ["metadata", "attributes"],
-                "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "title": "Metadata about the dataset metadata (maybe meta-metadata?)",
-                        "description": "Metadata about the dataset, including last change date, user, etc.",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "title": "Last change date and time",
-                                "description": "Date and time when the dataset metadata was modified the last time."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "title": "Last change user",
-                                "description": "User that changed the dataset metadata for the last time."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "title": "Image URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "title": "Dataset metadata",
-                        "description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
-                        "required": [
-                            "dcterms:identifier",
-                            "dcterms:title",
-                            "dcterms:description",
-                            "dcterms:accessRights",
-                            "bv:affiliatedPersons"
-                        ],
-                        "properties": {
-                            "dcterms:identifier": {
-                                "type": "string",
-                                "title": "Dataset identifier",
-                                "description": "Unique identifier for the dataset."
-                            },
-                            "dcterms:title": {
-                                "type": "object",
-                                "title": "Title",
-                                "description": "Title of the dataset.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                },
-                                "required": ["de", "fr"]
-                            },
-                            "dcterms:description": {
-                                "type": "object",
-                                "title": "Description",
-                                "description": "Description of the dataset. May go into details about the dataset content.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                },
-                                "required": ["de", "fr"]
-                            },
-                            "dcterms:accessRights": {
-                                "type": "string",
-                                "title": "Access rights",
-                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
-                                "enum": [
-                                    "CONFIDENTIAL",
-                                    "NON_PUBLIC",
-                                    "PUBLIC",
-                                    "RESTRICTED",
-                                    "SENSITIVE"
-                                ]
-                            },
-                            "dcterms:publisher": {
-                                "type": "string",
-                                "title": "Publisher",
-                                "description": "Name of the entity (person or organization) who published the dataset."
-                            },
-                            "dcat:contactPoint": {
-                                "type": "object",
-                                "title": "Contact point",
-                                "description": "Contact information for potential inquiries abou the dataset.",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "email": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["name", "email"]
-                            },
-                            "dcterms:issued": {
-                                "title": "Issued date",
-                                "description": "Date when the dataset was formally issued.",
-                                "type": ["string", "null"],
-                                "format": "date"
-                            },
-                            "dcat:keyword": {
-                                "type": ["array","null"],
-                                "title": "Keywords",
-                                "description": "Keywords describing the dataset.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcterms:accrualPeriodicity": {
-                                "type": "string",
-                                "title": "Accrual periodicity",
-                                "description": "Frequency with which dataset is updated (e.g., 'Annual').",
-                                "enum": [
-                                    "OTHER",
-                                    "HOURLY",
-                                    "UNKNOWN",
-                                    "QUARTERLY",
-                                    "NEVER",
-				                    "MONTHLY",	
-                                    "ANNUAL",
-                                    "DAILY",
-                                    "AS_NEEDED"
-                                ]
-                            },
-                            "dcterms:modified": {
-                                "type": ["string", "null"],
-                                "format": "date",
-                                "title": "Last modification date",
-                                "description": "Last modification date of the dataset (not to be confused with the dataset metadata)."
-                            },
-                            "bv:affiliatedPersons": {
-                                "type": "array",
-                                "title": "Affiliated person(s)",
-                                "description": "List of affiliated people, their contact address and respective roles.",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "name": {
-                                            "type": "string"
-                                        },
-                                        "email": {
-                                            "type": "string"
-                                        },
-                                        "role": {
-                                            "type": "string",
-                                            "description": "role",
-                                            "enum": [
-                                                "dataOwner",
-                                                "dataSteward",
-                                                "dataCustodian"
-                                            ]
-                                        }
-                                    },
-                                    "required": ["name", "email", "role"]
-                                },
-                                "minItems": 1,
-                                "contains": {
-                                    "type": "object",
-                                    "properties": {
-                                        "role": {
-                                            "const": "dataOwner"
-                                        }
-                                    },
-                                    "required": ["role"]
-                                }
-                            },
-                            "adms:status": {
-                                "type": "string",
-                                "title": "Status",
-                                "description": "Current status of the dataset (sample enumeration).",
-                                "enum": [
-                                    "workInProgress",
-                                    "validated",
-                                    "published",
-                                    "deleted",
-                                    "archived"
-                                ]
-                            },
-                            "bv:classification": {
-                                "type": "string",
-                                "title": "Classification level",
-                                "description": "Classification level of the dataset (sample enumeration).",
-                                "enum": [
-                                    "none",
-                                    "internal",
-                                    "confidential",
-                                    "secret"
-                                ]
-                            },
-                            "bv:personalData": {
-                                "type": "string",
-                                "title": "Categorization regarding data protection act",
-                                "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
-                                "enum": [
-                                    "none",
-                                    "personalData",
-                                    "sensitivePersonalData"
-                                ]
-                            },
-                            "bv:typeOfData": {
-                                "type": "string",
-                                "description": "Specifies the type of data (structured, unstructured, etc.).",
-                                "enum": [
-                                    "thematicData",
-                                    "referenceData",
-                                    "masterData",
-                                    "unstructuredData"
-                                ]
-                            },
-                            "bv:archivalValue": {
-                                "type": "boolean",
-                                "description": "Indicates if this dataset has archival value."
-                            },
-                            "bv:opendata.swiss": {
-                                "type": "object",
-                                "description": "Reference to the Open Government Data publication ID.",
-                                "properties": {
-                                    "bv:mustBePublished": {
-                                        "type": "boolean"
-                                    },
-                                    "dcterms:identifier": {
-                                        "type": "string",
-                                        "description": "Identifier for the OGD publication"
-                                    },
-                                    "dcat:accessURL": {
-                                        "type": "string",
-                                        "format": "uri",
-                                        "description": "URL on opendata.swiss"
-                                    }
-                                }
-                            },
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"$id": "https://example.com/dataCatalogSchema.json",
+	"title": "Data Catalog Schema",
+	"description": "JSON Schema for validating data catalog entries, including datasets and datasetSeries.",
+	"type": "object",
+	"properties": {
+		"datasets": {
+			"type": "array",
+			"additionalProperties": false,
+			"description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
+			"items": {
+				"type": "object",
+				"title": "Dataset metadata",
+				"description": "One item (i.e., one datset metadata) in the collection of datasets.",
+				"properties": {
+					"attributes": {
+						"type": "object",
+						"additionalProperties": false,
+						"title": "Dataset metadata",
+						"description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
+						"required": [
+							"dcterms:identifier",
+							"dcterms:title",
+							"dcterms:description",
+							"dcterms:accessRights",
+							"bv:affiliatedPersons"
+						],
+						"properties": {
+							"imageURL": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"title": "Image URL",
+								"description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+							},
+							"dcterms:identifier": {
+								"type": "string",
+								"title": "Dataset identifier",
+								"description": "Unique identifier for the dataset."
+							},
+							"dcterms:title": {
+								"type": "object",
+								"title": "Title",
+								"description": "Title of the dataset.",
+								"properties": {
+									"de": {
+										"type": "string",
+										"title": "Deutsch"
+									},
+									"fr": {
+										"type": "string",
+										"title": "Français"
+									},
+									"it": {
+										"type": "string",
+										"title": "Italiano"
+									},
+									"en": {
+										"type": "string",
+										"title": "English"
+									}
+								},
+								"required": [
+									"de",
+									"fr"
+								]
+							},
+							"dcterms:description": {
+								"type": "object",
+								"title": "Description",
+								"description": "Description of the dataset. May go into details about the dataset content.",
+								"properties": {
+									"de": {
+										"type": "string",
+										"title": "Deutsch"
+									},
+									"fr": {
+										"type": "string",
+										"title": "Français"
+									},
+									"it": {
+										"type": "string",
+										"title": "Italiano"
+									},
+									"en": {
+										"type": "string",
+										"title": "English"
+									}
+								},
+								"required": [
+									"de",
+									"fr"
+								]
+							},
+							"dcterms:accessRights": {
+								"type": "string",
+								"title": "Access rights",
+								"description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+								"enum": [
+									"CONFIDENTIAL",
+									"NON_PUBLIC",
+									"PUBLIC",
+									"RESTRICTED",
+									"SENSITIVE"
+								]
+							},
+							"dcterms:publisher": {
+								"type": "string",
+								"title": "Publisher",
+								"description": "Name of the entity (person or organization) who published the dataset."
+							},
+							"dcat:contactPoint": {
+								"type": "object",
+								"title": "Contact point",
+								"description": "Contact information for potential inquiries abou the dataset.",
+								"properties": {
+									"name": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name",
+									"email"
+								]
+							},
+							"dcterms:issued": {
+								"title": "Issued date",
+								"description": "Date when the dataset was formally issued.",
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "date"
+							},
+							"dcat:keyword": {
+								"type": [
+									"array",
+									"null"
+								],
+								"title": "Keywords",
+								"description": "Keywords describing the dataset.",
+								"items": {
+									"type": "string"
+								}
+							},
+							"dcterms:accrualPeriodicity": {
+								"type": "string",
+								"title": "Accrual periodicity",
+								"description": "Frequency with which dataset is updated (e.g., 'Annual').",
+								"enum": [
+									"OTHER",
+									"HOURLY",
+									"UNKNOWN",
+									"QUARTERLY",
+									"NEVER",
+									"MONTHLY",
+									"ANNUAL",
+									"DAILY",
+									"AS_NEEDED"
+								]
+							},
+							"dcterms:modified": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "date",
+								"title": "Last modification date",
+								"description": "Last modification date of the dataset (not to be confused with the dataset metadata)."
+							},
+							"bv:affiliatedPersons": {
+								"type": "array",
+								"title": "Affiliated person(s)",
+								"description": "List of affiliated people, their contact address and respective roles.",
+								"items": {
+									"type": "object",
+									"properties": {
+										"name": {
+											"type": "string"
+										},
+										"email": {
+											"type": "string"
+										},
+										"role": {
+											"type": "string",
+											"description": "role",
+											"enum": [
+												"dataOwner",
+												"dataSteward",
+												"dataCustodian"
+											]
+										}
+									},
+									"required": [
+										"name",
+										"email",
+										"role"
+									]
+								},
+								"minItems": 1,
+								"contains": {
+									"type": "object",
+									"properties": {
+										"role": {
+											"const": "dataOwner"
+										}
+									},
+									"required": [
+										"role"
+									]
+								}
+							},
+							"adms:status": {
+								"type": "string",
+								"title": "Status",
+								"description": "Current status of the dataset (sample enumeration).",
+								"enum": [
+									"workInProgress",
+									"validated",
+									"published",
+									"deleted",
+									"archived"
+								]
+							},
+							"bv:classification": {
+								"type": "string",
+								"title": "Classification level",
+								"description": "Classification level of the dataset (sample enumeration).",
+								"enum": [
+									"none",
+									"internal",
+									"confidential",
+									"secret"
+								]
+							},
+							"bv:personalData": {
+								"type": "string",
+								"title": "Categorization regarding data protection act",
+								"description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
+								"enum": [
+									"none",
+									"personalData",
+									"sensitivePersonalData"
+								]
+							},
+							"bv:typeOfData": {
+								"type": "string",
+								"description": "Specifies the type of data (structured, unstructured, etc.).",
+								"enum": [
+									"thematicData",
+									"referenceData",
+									"masterData",
+									"unstructuredData"
+								]
+							},
+							"bv:archivalValue": {
+								"type": "boolean",
+								"description": "Indicates if this dataset has archival value."
+							},
+							"bv:opendata.swiss": {
+								"type": "object",
+								"description": "Reference to the Open Government Data publication ID.",
+								"properties": {
+									"bv:mustBePublished": {
+										"type": "boolean"
+									},
+									"dcterms:identifier": {
+										"type": "string",
+										"description": "Identifier for the OGD publication"
+									},
+									"dcat:accessURL": {
+										"type": "string",
+										"format": "uri",
+										"description": "URL on opendata.swiss"
+									}
+								}
+							},
 							"bv:i14y": {
 								"type": "object",
-                                "description": "Reference to the I14Y publication ID.",
-                                "properties": {
-                                    "bv:mustBePublished": {
-                                        "type": "boolean"
-                                    },
-                                    "dcterms:identifier": {
-                                        "type": "string",
-                                        "description": "Identifier for the I14Y publication"
-                                    },
-                                    "dcat:accessURL": {
-                                        "type": "string",
-                                        "format": "uri",
-                                        "description": "URL on I14Y"
-                                    }
-                                }
+								"description": "Reference to the I14Y publication ID.",
+								"properties": {
+									"bv:mustBePublished": {
+										"type": "boolean"
+									},
+									"dcterms:identifier": {
+										"type": "string",
+										"description": "Identifier for the I14Y publication"
+									},
+									"dcat:accessURL": {
+										"type": "string",
+										"format": "uri",
+										"description": "URL on I14Y"
+									}
+								}
 							},
-                            "dcat:themeTaxonomy": {
-                                "type": ["array","null"],
-                                "description": "Reference or URL to a theme taxonomy classification.",
-                                "items": {
-                                    "type": "string",
-                                    "enum": [
-                                        "populationAndSociety",
-                                        "agricultureFisheriesForestryFood",
-                                        "internationalTopics",
-                                        "environment"
-                                    ]
-                                }
-                            },
-                            "dcat:landingPage": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "Landing page or homepage for the dataset."
-                            },
-                            "dcterms:spatial": {
-                                "type": "string",
-                                "description": "Spatial/geographical coverage."
-                            },
-                            "dcterms:temporal": {
-                                "type": "string",
-                                "description": "Temporal coverage of the dataset."
-                            },
-                            "bv:legalBasis": {
-                                "title": "Legal basis",
-                                "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
-                                "type": ["array","null"],
-                                "items": {
-                                    "title": "URI",
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
-                            "bv:businessProcess": {
-                                "type": ["array","null"],
-                                "description": "Related business process or context.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "bv:retentionPeriod": {
-                                "type": "integer",
-                                "description": "Retention period for the dataset."
-                            },
-                            "dcat:catalog": {
-                                "type": "string",
-                                "description": "Indicates which catalog this dataset belongs to."
-                            },
-                            "prov:wasDerivedFrom": {
-                                "type": ["array","null"],
-                                "description": "Source from which this dataset was derived.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "bv:geoIdentifier": {
-                                "type": "string",
-                                "description": "Geographical identifier (e.g., BFS numbers)."
-                            },
-                            "foaf:page": {
-                                "type": ["array","null"],
-                                "description": "Any related page or resource.",
-                                "items": {
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
-                            "bv:comments": {
-                                "type": "string",
-                                "description": "Additional comments about the dataset."
-                            },
-                            "bv:abrogation": {
-                                "type": ["string", "null"],
-                                "format": "date",
-                                "description": "Indicates if the dataset was abrogated or replaced."
-                            },
-                            "bv:itSystem": {
-                                "type": "string",
-                                "description": "Name of the IT system managing this dataset."
-                            },
-                            "dcat:inSeries": {
-                                "type": "string",
-                                "description": "Reference to the series this dataset belongs to."
-                            },
-                            "dcterms:replaces": {
-                                "type": ["array","null"],
-                                "description": "ID of datasets replaced by this one",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcat:distribution": {
-                                "type": ["array","null"],
-                                "description": "Distribution info describing how and where to access the dataset.",
-                                "items": {
-                                    "type": "object",
-                                    "additionalProperties": false,
-                                    "required": ["attributes"],
-                                    "properties": {
-                                        "attributes": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "required": [
-                                                "dcterms:identifier",
-                                                "dcat:accessURL",
-                                                "dcterms:title",
-                                                "dcterms:description"
-                                            ],
-                                            "properties": {
-                                                "dcterms:identifier": {
-                                                    "type": "string",
-                                                    "description": "Identifier for this distribution."
-                                                },
-                                                "dcat:accessURL": {
-                                                    "type": "string",
-                                                    "format": "uri",
-                                                    "description": "URL for accessing this distribution."
-                                                },
-                                                "adms:status": {
-                                                    "type": "string",
-                                                    "description": "Status of this distribution (e.g., 'active', 'deprecated').",
-                                                    "enum": [
-                                                        "workInProgress",
-                                                        "validated",
-                                                        "published",
-                                                        "deleted",
-                                                        "archived"
-                                                    ]
-                                                },
-                                                "dcterms:format": {
-                                                    "type": "string",
-                                                    "description": "File format (e.g., CSV, JSON)."
-                                                },
-                                                "dcterms:modified": {
-                                                    "type": ["string", "null"],
-                                                    "format": "date",
-                                                    "description": "When the distribution file was last modified."
-                                                },
-                                                "dcat:downloadURL": {
-                                                    "type": ["string", "null"],
-                                                    "format": "uri",
-                                                    "description": "Download URL of the distribution file."
-                                                },
-                                                "dcterms:title": {
-                                                    "type": "object",
-                                                    "description": "Title for the distribution, in multiple languages.",
-                                                    "properties": {
-                                                        "de": {
-                                                            "type": "string",
-                                                            "title": "Deutsch"
-                                                        },
-                                                        "fr": {
-                                                            "type": "string",
-                                                            "title": "Français"
-                                                        },
-                                                        "it": {
-                                                            "type": "string",
-                                                            "title": "Italiano"
-                                                        },
-                                                        "en": {
-                                                            "type": "string",
-                                                            "title": "English"
-                                                        }
-                                                    }
-                                                },
-                                                "dcterms:description": {
-                                                    "type": "object",
-                                                    "description": "Description for the distribution, in multiple languages.",
-                                                    "properties": {
-                                                        "de": {
-                                                            "type": "string",
-                                                            "title": "Deutsch"
-                                                        },
-                                                        "fr": {
-                                                            "type": "string",
-                                                            "title": "Français"
-                                                        },
-                                                        "it": {
-                                                            "type": "string",
-                                                            "title": "Italiano"
-                                                        },
-                                                        "en": {
-                                                            "type": "string",
-                                                            "title": "English"
-                                                        }
-                                                    }
-                                                },
-                                                "dcterms:conformsTo": {
-                                                    "type": "string",
-                                                    "description": "Reference to a standard or specification the distribution conforms to."
-                                                },
-                                                "dcterms:license": {
-                                                    "type": "string",
-                                                    "description": "License under which this distribution is released.",
-                                                    "enum": [
-                                                        "terms_open",
-                                                        "terms_by",
-                                                        "terms_ask",
-                                                        "terms_by_ask",
-                                                        "cc-zero"
-                                                    ]
-                                                },
-                                                "bv:comments": {
-                                                    "type": "string",
-                                                    "description": "Additional comments about the distribution."
-                                                },
-                                                "dcat:accessService": {
-                                                    "type": "string",
-                                                    "description": "Indicates a service used to provide access to the data."
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "datasetSeries": {
-            "type": "array",
-            "description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
-            "items": {
-                "type": "object",
-                "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01').",
-                "required": ["metadata", "attributes"],
-                "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "description": "Metadata about the dataset series (last update date, user, image, etc.).",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Date/time when the series was last changed."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "description": "User or identifier who last updated the series."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL linking to an image for this series."
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "description": "Descriptive attributes for the dataset series.",
-                        "required": [
-                            "dcterms:identifier",
-                            "dcterms:title",
-                            "bv:classification",
-                            "bv:personalData"
-                        ],
-                        "properties": {
-                            "dcterms:identifier": {
-                                "type": "string",
-                                "description": "Unique identifier for the dataset series."
-                            },
-                            "dcterms:title": {
-                                "type": "object",
-                                "description": "Title for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string"
-                                    },
-                                    "fr": {
-                                        "type": "string"
-                                    },
-                                    "it": {
-                                        "type": "string"
-                                    },
-                                    "en": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-                                "type": "object",
-                                "description": "Description for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string"
-                                    },
-                                    "fr": {
-                                        "type": "string"
-                                    },
-                                    "it": {
-                                        "type": "string"
-                                    },
-                                    "en": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "dcat:contactPoint": {
-                                "type": "object",
-                                "description": "Contact information for inquiries.",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "email": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["name", "email"]
-                            },
-                            "dcterms:publisher": {
-                                "type": "string",
-                                "description": "Publisher or organization responsible for the series."
-                            },
-                            "adms:status": {
-                                "type": "string",
-                                "description": "Current status of the dataset (sample enumeration).",
-                                "enum": [
-                                    "workInProgress",
-                                    "validated",
-                                    "published",
-                                    "deleted",
-                                    "archived"
-                                ]
-                            },
-                            "dcat:dataset": {
-                                "type": ["array","null"],
-                                "description": "Indicates which dataset(s) this series serves or is related to.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "foaf:page": {
-                                "type": ["array","null"],
-                                "description": "Any related page or resource.",
-                                "items": {
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
-                            "bv:comment": {
-                                "type": "string",
-                                "description": "Additional comments or notes about the series."
-                            },
-                            "dcat:keyword": {
-                                "type": ["array","null"],
-                                "description": "Keywords describing the dataset Serie.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "bv:classification": {
-                                "type": "string",
-                                "description": "Classification level of the dataset (sample enumeration).",
-                                "enum": [
-                                    "none",
-                                    "internal",
-                                    "confidential",
-                                    "secret"
-                                ]
-                            },
-                            "bv:personalData": {
-                                "type": "string",
-                                "description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
-                                "enum": [
-                                    "none",
-                                    "personalData",
-                                    "sensitivePersonalData"
-                                ]
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "dataServices": {
-            "type": "array",
-            "description": "Container for dcat:DataService",
-            "items": {
-                "type": "object",
-                "description": "structure of DataService",
-                "required": ["metadata", "attributes"],
-                "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "description": "Metadata about the dataset series (last update date, user, image, etc.).",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Date/time when the series was last changed."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "description": "User or identifier who last updated the series."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL linking to an image for this series."
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "description": "attributes for the DataService",
-                        "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
-                        "properties": {
-                            "dcterms:identifier": {
-                                "type": "string",
-                                "description": "Unique identifier for the DataService."
-                            },
-                            "dcterms:title": {
-                                "type": "object",
-                                "description": "Title for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string"
-                                    },
-                                    "fr": {
-                                        "type": "string"
-                                    },
-                                    "it": {
-                                        "type": "string"
-                                    },
-                                    "en": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-                                "type": "object",
-                                "description": "Description for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string"
-                                    },
-                                    "fr": {
-                                        "type": "string"
-                                    },
-                                    "it": {
-                                        "type": "string"
-                                    },
-                                    "en": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "dcterms:publisher": {
-                                "type": "string",
-                                "description": "Publisher or organization responsible for the series."
-                            },
-                            "dcat:contactPoint": {
-                                "type": "object",
-                                "description": "Contact information for inquiries.",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "email": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["name", "email"]
-                            },
-                            "dcterms:accessRights": {
-                                "type": "string",
-                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
-                                "enum": [
-                                    "CONFIDENTIAL",
-                                    "NON_PUBLIC",
-                                    "PUBLIC",
-                                    "RESTRICTED",
-                                    "SENSITIVE"
-                                ]
-                            },
-                            "dcat:endopointURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL of the service."
-                            },
-                            "adms:status": {
-                                "type": "string",
-                                "description": "Current status of the dataset (sample enumeration).",
-                                "enum": [
-                                    "workInProgress",
-                                    "validated",
-                                    "published",
-                                    "deleted",
-                                    "archived"
-                                ]
-                            },
-                            "dcat:servesDataset": {
-                                "type": ["array","null"],
-                                "description": "IDs of the datasets served",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcat:endpointDescription": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL of documentation."
-                            },
-                            "foaf:page": {
-                                "type": ["array","null"],
-                                "description": "Any related page or resource.",
-                                "items": {
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
-                            "bv:comments": {
-                                "type": "string",
-                                "description": "Additional comments about the DataService."
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "catalogs": {
-            "type": "array",
-            "description": "container for dcat:Catalog",
-            "items": {
-                "type": "object",
-                "description": "structure of Catalog",
-                "required": ["metadata", "attributes"],
-                "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "description": "Metadata about the catalog (last update date, user, image, etc.).",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Date/time when the series was last changed."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "description": "User or identifier who last updated the series."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL linking to an image for this series."
-                            }
-                        }
-                    },
-                    "attributes": {
-                        "type": "object",
-                        "description": "attributes for the Catalog",
-                        "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
-                        "properties": {
-                            "dcterms:identifier": {
-                                "type": "string",
-                                "description": "Unique identifier for the Catalog."
-                            },
-                            "dcterms:title": {
-                                "type": "object",
-                                "description": "Title for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string"
-                                    },
-                                    "fr": {
-                                        "type": "string"
-                                    },
-                                    "it": {
-                                        "type": "string"
-                                    },
-                                    "en": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-                                "type": "object",
-                                "description": "Description for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-                                        "type": "string"
-                                    },
-                                    "fr": {
-                                        "type": "string"
-                                    },
-                                    "it": {
-                                        "type": "string"
-                                    },
-                                    "en": {
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "dcterms:publisher": {
-                                "type": "string",
-                                "description": "Publisher or organization responsible for the series."
-                            },
-                            "dcat:contactPoint": {
-                                "type": "object",
-                                "description": "Contact information for inquiries.",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "email": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": ["name", "email"]
-                            },
-                            "dcterms:accessRights": {
-                                "type": "string",
-                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
-                                "enum": [
-                                    "CONFIDENTIAL",
-                                    "NON_PUBLIC",
-                                    "PUBLIC",
-                                    "RESTRICTED",
-                                    "SENSITIVE"
-                                ]
-                            },
-                            "foaf:homepage": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "homepage for the catalog"
-                            },
-                            "dcat:dataset": {
-                                "type": ["array","null"],
-                                "description": "IDs of the datasets in the catalog",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcat:service": {
-                                "type": ["array","null"],
-                                "description": "IDs of the dataServices in the catalog",
-                                "items": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
+							"dcat:themeTaxonomy": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Reference or URL to a theme taxonomy classification.",
+								"items": {
+									"type": "string",
+									"enum": [
+										"populationAndSociety",
+										"agricultureFisheriesForestryFood",
+										"internationalTopics",
+										"environment"
+									]
+								}
+							},
+							"dcat:landingPage": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"description": "Landing page or homepage for the dataset."
+							},
+							"dcterms:spatial": {
+								"type": "string",
+								"description": "Spatial/geographical coverage."
+							},
+							"dcterms:temporal": {
+								"type": "string",
+								"description": "Temporal coverage of the dataset."
+							},
+							"bv:legalBasis": {
+								"title": "Legal basis",
+								"description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
+								"type": [
+									"array",
+									"null"
+								],
+								"items": {
+									"title": "URI",
+									"type": [
+										"string",
+										"null"
+									],
+									"format": "uri"
+								}
+							},
+							"bv:businessProcess": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Related business process or context.",
+								"items": {
+									"type": "string"
+								}
+							},
+							"bv:retentionPeriod": {
+								"type": "integer",
+								"description": "Retention period for the dataset."
+							},
+							"dcat:catalog": {
+								"type": "string",
+								"description": "Indicates which catalog this dataset belongs to."
+							},
+							"prov:wasDerivedFrom": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Source from which this dataset was derived.",
+								"items": {
+									"type": "string"
+								}
+							},
+							"bv:geoIdentifier": {
+								"type": "string",
+								"description": "Geographical identifier (e.g., BFS numbers)."
+							},
+							"foaf:page": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Any related page or resource.",
+								"items": {
+									"type": [
+										"string",
+										"null"
+									],
+									"format": "uri"
+								}
+							},
+							"bv:comments": {
+								"type": "string",
+								"description": "Additional comments about the dataset."
+							},
+							"bv:abrogation": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "date",
+								"description": "Indicates if the dataset was abrogated or replaced."
+							},
+							"bv:itSystem": {
+								"type": "string",
+								"description": "Name of the IT system managing this dataset."
+							},
+							"dcat:inSeries": {
+								"type": "string",
+								"description": "Reference to the series this dataset belongs to."
+							},
+							"dcterms:replaces": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "ID of datasets replaced by this one",
+								"items": {
+									"type": "string"
+								}
+							},
+							"dcat:distribution": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Distribution info describing how and where to access the dataset.",
+								"items": {
+									"type": "object",
+									"additionalProperties": false,
+									"properties": {
+										"attributes": {
+											"type": "object",
+											"additionalProperties": false,
+											"required": [
+												"dcterms:identifier",
+												"dcat:accessURL",
+												"dcterms:title",
+												"dcterms:description"
+											],
+											"properties": {
+												"dcterms:identifier": {
+													"type": "string",
+													"description": "Identifier for this distribution."
+												},
+												"dcat:accessURL": {
+													"type": "string",
+													"format": "uri",
+													"description": "URL for accessing this distribution."
+												},
+												"adms:status": {
+													"type": "string",
+													"description": "Status of this distribution (e.g., 'active', 'deprecated').",
+													"enum": [
+														"workInProgress",
+														"validated",
+														"published",
+														"deleted",
+														"archived"
+													]
+												},
+												"dcterms:format": {
+													"type": "string",
+													"description": "File format (e.g., CSV, JSON)."
+												},
+												"dcterms:modified": {
+													"type": [
+														"string",
+														"null"
+													],
+													"format": "date",
+													"description": "When the distribution file was last modified."
+												},
+												"dcat:downloadURL": {
+													"type": [
+														"string",
+														"null"
+													],
+													"format": "uri",
+													"description": "Download URL of the distribution file."
+												},
+												"dcterms:title": {
+													"type": "object",
+													"description": "Title for the distribution, in multiple languages.",
+													"properties": {
+														"de": {
+															"type": "string",
+															"title": "Deutsch"
+														},
+														"fr": {
+															"type": "string",
+															"title": "Français"
+														},
+														"it": {
+															"type": "string",
+															"title": "Italiano"
+														},
+														"en": {
+															"type": "string",
+															"title": "English"
+														}
+													}
+												},
+												"dcterms:description": {
+													"type": "object",
+													"description": "Description for the distribution, in multiple languages.",
+													"properties": {
+														"de": {
+															"type": "string",
+															"title": "Deutsch"
+														},
+														"fr": {
+															"type": "string",
+															"title": "Français"
+														},
+														"it": {
+															"type": "string",
+															"title": "Italiano"
+														},
+														"en": {
+															"type": "string",
+															"title": "English"
+														}
+													}
+												},
+												"dcterms:conformsTo": {
+													"type": "string",
+													"description": "Reference to a standard or specification the distribution conforms to."
+												},
+												"dcterms:license": {
+													"type": "string",
+													"description": "License under which this distribution is released.",
+													"enum": [
+														"terms_open",
+														"terms_by",
+														"terms_ask",
+														"terms_by_ask",
+														"cc-zero"
+													]
+												},
+												"bv:comments": {
+													"type": "string",
+													"description": "Additional comments about the distribution."
+												},
+												"dcat:accessService": {
+													"type": "string",
+													"description": "Indicates a service used to provide access to the data."
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		},
+		"datasetSeries": {
+			"type": "array",
+			"description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
+			"items": {
+				"type": "object",
+				"description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01').",
+				"properties": {
+					"attributes": {
+						"type": "object",
+						"description": "Descriptive attributes for the dataset series.",
+						"required": [
+							"dcterms:identifier",
+							"dcterms:title",
+							"bv:classification",
+							"bv:personalData"
+						],
+						"properties": {
+							"imageURL": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"title": "Image URL",
+								"description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+							},
+							"dcterms:identifier": {
+								"type": "string",
+								"description": "Unique identifier for the dataset series."
+							},
+							"dcterms:title": {
+								"type": "object",
+								"description": "Title for the series in multiple languages.",
+								"properties": {
+									"de": {
+										"type": "string"
+									},
+									"fr": {
+										"type": "string"
+									},
+									"it": {
+										"type": "string"
+									},
+									"en": {
+										"type": "string"
+									}
+								}
+							},
+							"dcterms:description": {
+								"type": "object",
+								"description": "Description for the series in multiple languages.",
+								"properties": {
+									"de": {
+										"type": "string"
+									},
+									"fr": {
+										"type": "string"
+									},
+									"it": {
+										"type": "string"
+									},
+									"en": {
+										"type": "string"
+									}
+								}
+							},
+							"dcat:contactPoint": {
+								"type": "object",
+								"description": "Contact information for inquiries.",
+								"properties": {
+									"name": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name",
+									"email"
+								]
+							},
+							"dcterms:publisher": {
+								"type": "string",
+								"description": "Publisher or organization responsible for the series."
+							},
+							"adms:status": {
+								"type": "string",
+								"description": "Current status of the dataset (sample enumeration).",
+								"enum": [
+									"workInProgress",
+									"validated",
+									"published",
+									"deleted",
+									"archived"
+								]
+							},
+							"dcat:dataset": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Indicates which dataset(s) this series serves or is related to.",
+								"items": {
+									"type": "string"
+								}
+							},
+							"foaf:page": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Any related page or resource.",
+								"items": {
+									"type": [
+										"string",
+										"null"
+									],
+									"format": "uri"
+								}
+							},
+							"bv:comment": {
+								"type": "string",
+								"description": "Additional comments or notes about the series."
+							},
+							"dcat:keyword": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Keywords describing the dataset Serie.",
+								"items": {
+									"type": "string"
+								}
+							},
+							"bv:classification": {
+								"type": "string",
+								"description": "Classification level of the dataset (sample enumeration).",
+								"enum": [
+									"none",
+									"internal",
+									"confidential",
+									"secret"
+								]
+							},
+							"bv:personalData": {
+								"type": "string",
+								"description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
+								"enum": [
+									"none",
+									"personalData",
+									"sensitivePersonalData"
+								]
+							}
+						}
+					}
+				}
+			}
+		},
+		"dataServices": {
+			"type": "array",
+			"description": "Container for dcat:DataService",
+			"items": {
+				"type": "object",
+				"description": "structure of DataService",
+				"properties": {
+					"attributes": {
+						"type": "object",
+						"description": "attributes for the DataService",
+						"required": [
+							"dcterms:identifier",
+							"dcterms:title",
+							"dcterms:description",
+							"dcterms:publisher",
+							"dcat:contactPoint"
+						],
+						"properties": {
+							"dcterms:identifier": {
+								"type": "string",
+								"description": "Unique identifier for the DataService."
+							},
+							"dcterms:title": {
+								"type": "object",
+								"description": "Title for the series in multiple languages.",
+								"properties": {
+									"de": {
+										"type": "string"
+									},
+									"fr": {
+										"type": "string"
+									},
+									"it": {
+										"type": "string"
+									},
+									"en": {
+										"type": "string"
+									}
+								}
+							},
+							"dcterms:description": {
+								"type": "object",
+								"description": "Description for the series in multiple languages.",
+								"properties": {
+									"de": {
+										"type": "string"
+									},
+									"fr": {
+										"type": "string"
+									},
+									"it": {
+										"type": "string"
+									},
+									"en": {
+										"type": "string"
+									}
+								}
+							},
+							"dcterms:publisher": {
+								"type": "string",
+								"description": "Publisher or organization responsible for the series."
+							},
+							"dcat:contactPoint": {
+								"type": "object",
+								"description": "Contact information for inquiries.",
+								"properties": {
+									"name": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name",
+									"email"
+								]
+							},
+							"dcterms:accessRights": {
+								"type": "string",
+								"description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+								"enum": [
+									"CONFIDENTIAL",
+									"NON_PUBLIC",
+									"PUBLIC",
+									"RESTRICTED",
+									"SENSITIVE"
+								]
+							},
+							"dcat:endopointURL": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"description": "URL of the service."
+							},
+							"adms:status": {
+								"type": "string",
+								"description": "Current status of the dataset (sample enumeration).",
+								"enum": [
+									"workInProgress",
+									"validated",
+									"published",
+									"deleted",
+									"archived"
+								]
+							},
+							"dcat:servesDataset": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "IDs of the datasets served",
+								"items": {
+									"type": "string"
+								}
+							},
+							"dcat:endpointDescription": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"description": "URL of documentation."
+							},
+							"foaf:page": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "Any related page or resource.",
+								"items": {
+									"type": [
+										"string",
+										"null"
+									],
+									"format": "uri"
+								}
+							},
+							"bv:comments": {
+								"type": "string",
+								"description": "Additional comments about the DataService."
+							}
+						}
+					}
+				}
+			}
+		},
+		"catalogs": {
+			"type": "array",
+			"description": "container for dcat:Catalog",
+			"items": {
+				"type": "object",
+				"description": "structure of Catalog",
+				"properties": {
+					"attributes": {
+						"type": "object",
+						"description": "attributes for the Catalog",
+						"required": [
+							"dcterms:identifier",
+							"dcterms:title",
+							"dcterms:description",
+							"dcterms:publisher",
+							"dcat:contactPoint"
+						],
+						"properties": {
+							"imageURL": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"title": "Image URL",
+								"description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+							},
+							"dcterms:identifier": {
+								"type": "string",
+								"description": "Unique identifier for the Catalog."
+							},
+							"dcterms:title": {
+								"type": "object",
+								"description": "Title for the series in multiple languages.",
+								"properties": {
+									"de": {
+										"type": "string"
+									},
+									"fr": {
+										"type": "string"
+									},
+									"it": {
+										"type": "string"
+									},
+									"en": {
+										"type": "string"
+									}
+								}
+							},
+							"dcterms:description": {
+								"type": "object",
+								"description": "Description for the series in multiple languages.",
+								"properties": {
+									"de": {
+										"type": "string"
+									},
+									"fr": {
+										"type": "string"
+									},
+									"it": {
+										"type": "string"
+									},
+									"en": {
+										"type": "string"
+									}
+								}
+							},
+							"dcterms:publisher": {
+								"type": "string",
+								"description": "Publisher or organization responsible for the series."
+							},
+							"dcat:contactPoint": {
+								"type": "object",
+								"description": "Contact information for inquiries.",
+								"properties": {
+									"name": {
+										"type": "string"
+									},
+									"email": {
+										"type": "string"
+									}
+								},
+								"required": [
+									"name",
+									"email"
+								]
+							},
+							"dcterms:accessRights": {
+								"type": "string",
+								"description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+								"enum": [
+									"CONFIDENTIAL",
+									"NON_PUBLIC",
+									"PUBLIC",
+									"RESTRICTED",
+									"SENSITIVE"
+								]
+							},
+							"foaf:homepage": {
+								"type": [
+									"string",
+									"null"
+								],
+								"format": "uri",
+								"description": "homepage for the catalog"
+							},
+							"dcat:dataset": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "IDs of the datasets in the catalog",
+								"items": {
+									"type": "string"
+								}
+							},
+							"dcat:service": {
+								"type": [
+									"array",
+									"null"
+								],
+								"description": "IDs of the dataServices in the catalog",
+								"items": {
+									"type": "string"
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
This PR includes:
- Removal of the metadata blocks from the schema objects, as preparation for #19
- Moving the "required" information: fixes #20 
- Updates and fixes the attribute names and description: fixes #12 
- Updates some attributes to use established ontologies and vocabularies such as schema.org: fixes #13 