### PR TITLE
Schema fixes

### DIFF
--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -20,7 +20,7 @@
                         "title": "Dataset_metadata",
                         "description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
                         "properties": {
-                            "imageURL": {
+                            "schema:image": {
                                 "required": false,
 				"type": ["string", "null"],
                                 "format": "uri",
@@ -114,12 +114,12 @@
                                 "title": "Contact_point",
                                 "description": "Contact information for potential inquiries about the dataset.",
                                 "properties": {
-                                    "name": {
+                                    "schema:name": {
 					"required": true,
                                         "type": "string"
 					"title": "Name"
                                     },
-                                    "email": {
+                                    "schema:email": {
 					"required": true,
                                         "type": "string",
 					"title": "email"
@@ -166,7 +166,7 @@
                                 "title": "Last_modification_date",
                                 "description": "Last modification date of the data in the dataset."
                             },
-                            "bv:affiliatedPersons": {
+                            "schema:OrganizationRole": {
 				"required": true,
                                 "type": "array",
                                 "title": "Affiliated_persons",
@@ -174,17 +174,17 @@
                                 "items": {
                                     "type": "object",
                                     "properties": {
-                                        "name": {
+                                        "schema:name": {
 					    "required": true,
                                             "type": "string",
 					    "title": "Name"
                                         },
-                                        "email": {
+                                        "schema:email": {
 					    "required": true,
                                             "type": "string",
 					    "title": "email"
                                         },
-                                        "role": {
+                                        "schema:roleName": {
 					    "required": true,
                                             "type": "string",
 					    "title": "Role",
@@ -201,7 +201,7 @@
                                 "contains": {
                                     "type": "object",
                                     "properties": {
-                                        "role": {
+                                        "schema:roleName": {
 					    "required": true,
                                             "const": "dataOwner"
                                         }
@@ -350,7 +350,7 @@
                                 "type": "string",
                                 "description": "Temporal coverage of the dataset. For example, the first and last measurement years for a timeseries."
                             },
-                            "bv:legalBasis": {
+                            "dpv:hasLegalBasis": {
 				"required": false,
                                 "title": "Legal_basis",
                                 "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
@@ -422,7 +422,7 @@
 	    			       }
 				 }
 			    },
-                            "bv:comments": {
+                            "schema:comment": {
 				"title": "comments",
 				"required": false,
                                 "type": "string",
@@ -590,7 +590,7 @@
                                                         "cc-zero"
                                                     ]
                                                 },
-                                                "bv:comments": {
+                                                "schema:comment": {
 						    "title": "comments",
 						    "required": false,
                                                     "type": "string",
@@ -624,7 +624,7 @@
                         "type": "object",
                         "description": "Descriptive attributes for the dataset series.",
                         "properties": {
-                            "imageURL": {
+                            "schema:image": {
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
@@ -699,12 +699,12 @@
 				"required": true,
                                 "type": "object",
                                 "properties": {
-                                    "name": {
+                                    "schema:name": {
 					"required": true,
                                         "type": "string",
 					"title": "Name"
                                     },
-                                    "email": {
+                                    "schema:email": {
 					"required": true,
                                         "type": "string"
 					"title": "email"
@@ -764,7 +764,7 @@
 	    			       }
 				 }
 			    },
-                            "bv:comment": {
+                            "schema:comment": {
 				"title": "comments",
 				"required": false,
                                 "type": "string",
@@ -819,7 +819,7 @@
                         "type": "object",
                         "description": "attributes for the DataService",
                         "properties": {
-                            "imageURL": {
+                            "schema:image": {
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
@@ -900,12 +900,12 @@
 				"required": true,
                                 "type": "object",
                                 "properties": {
-                                    "name": {
+                                    "schema:name": {
 					"required": true,
                                         "type": "string"
 					"title": "Name"
                                     },
-                                    "email": {
+                                    "schema:email": {
 					"required": true,
                                         "type": "string"
 					"title": "email"
@@ -986,7 +986,7 @@
 	    			       }
 				 }
 			    },
-                            "bv:comments": {
+                            "schema:comment": {
 				"title": "comments",
 				"required": false,
                                 "type": "string",
@@ -1009,7 +1009,7 @@
                         "type": "object",
                         "description": "Attributes for the Catalog",
                         "properties": {
-                            "imageURL": {
+                            "schema:image": {
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
@@ -1090,12 +1090,12 @@
 				"required": true,
                                 "type": "object",
                                 "properties": {
-                                    "name": {
+                                    "schema:name": {
 					"required": true,
                                         "type": "string"
 					"title": "Name"
                                     },
-                                    "email": {
+                                    "schema:email": {
 					"required": true,
                                         "type": "string"
 					"title": "email"

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -19,74 +19,78 @@
                         "additionalProperties": false,
                         "title": "Dataset metadata",
                         "description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
-                        "required": [
-                            "dcterms:identifier",
-                            "dcterms:title",
-                            "dcterms:description",
-                            "dcterms:accessRights",
-                            "bv:affiliatedPersons"
-                        ],
                         "properties": {
                             "imageURL": {
-                                "type": ["string", "null"],
+                                "required": false,
+				"type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                             },
 			    "dcterms:identifier": {
+				"required": true,
                                 "type": "string",
                                 "title": "Dataset identifier",
                                 "description": "Unique identifier for the dataset."
                             },
                             "dcterms:title": {
-                                "type": "object",
+                                "required": true,
+				"type": "object",
                                 "title": "Title",
                                 "description": "Title of the dataset.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string",
                                         "title": "English"
                                     }
-                                },
-                                "required": ["de", "fr"]
+                                }
                             },
                             "dcterms:description": {
+				"required": true,
                                 "type": "object",
                                 "title": "Description",
                                 "description": "Description of the dataset. May go into details about the dataset content.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string",
                                         "title": "English"
                                     }
-                                },
-                                "required": ["de", "fr"]
+                                }
                             },
                             "dcterms:accessRights": {
+				"required": true,
                                 "type": "string",
                                 "title": "Access rights",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
@@ -99,31 +103,36 @@
                                 ]
                             },
                             "dcterms:publisher": {
+				"required": true,
                                 "type": "string",
                                 "title": "Publisher",
                                 "description": "Name of the entity (person or organization) who published the dataset."
                             },
                             "dcat:contactPoint": {
+				"required": true,
                                 "type": "object",
                                 "title": "Contact point",
                                 "description": "Contact information for potential inquiries abou the dataset.",
                                 "properties": {
                                     "name": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "email": {
+					"required": true,
                                         "type": "string"
                                     }
-                                },
-                                "required": ["name", "email"]
+                                }
                             },
                             "dcterms:issued": {
+				"required": true,
                                 "title": "Issued date",
                                 "description": "Date when the dataset was formally issued.",
                                 "type": ["string", "null"],
                                 "format": "date"
                             },
                             "dcat:keyword": {
+				"required": false,
                                 "type": ["array","null"],
                                 "title": "Keywords",
                                 "description": "Keywords describing the dataset.",
@@ -132,6 +141,7 @@
                                 }
                             },
                             "dcterms:accrualPeriodicity": {
+				"required": true,
                                 "type": "string",
                                 "title": "Accrual periodicity",
                                 "description": "Frequency with which dataset is updated (e.g., 'Annual').",
@@ -141,19 +151,21 @@
                                     "UNKNOWN",
                                     "QUARTERLY",
                                     "NEVER",
-				                    "MONTHLY",	
+				    "MONTHLY",	
                                     "ANNUAL",
                                     "DAILY",
                                     "AS_NEEDED"
                                 ]
                             },
                             "dcterms:modified": {
+				"required": true,
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "title": "Last modification date",
                                 "description": "Last modification date of the dataset (not to be confused with the dataset metadata)."
                             },
                             "bv:affiliatedPersons": {
+				"required": true,
                                 "type": "array",
                                 "title": "Affiliated person(s)",
                                 "description": "List of affiliated people, their contact address and respective roles.",
@@ -161,12 +173,15 @@
                                     "type": "object",
                                     "properties": {
                                         "name": {
+					    "required": true,
                                             "type": "string"
                                         },
                                         "email": {
+					    "required": true,
                                             "type": "string"
                                         },
                                         "role": {
+					    "required": true,
                                             "type": "string",
                                             "description": "role",
                                             "enum": [
@@ -175,21 +190,21 @@
                                                 "dataCustodian"
                                             ]
                                         }
-                                    },
-                                    "required": ["name", "email", "role"]
+                                    }
                                 },
                                 "minItems": 1,
                                 "contains": {
                                     "type": "object",
                                     "properties": {
                                         "role": {
+					    "required": true,
                                             "const": "dataOwner"
                                         }
-                                    },
-                                    "required": ["role"]
+                                    }
                                 }
                             },
                             "adms:status": {
+				"required": true,
                                 "type": "string",
                                 "title": "Status",
                                 "description": "Current status of the dataset (sample enumeration).",
@@ -202,6 +217,7 @@
                                 ]
                             },
                             "bv:classification": {
+				"required": true,
                                 "type": "string",
                                 "title": "Classification level",
                                 "description": "Classification level of the dataset (sample enumeration).",
@@ -213,6 +229,7 @@
                                 ]
                             },
                             "bv:personalData": {
+				"required": true,
                                 "type": "string",
                                 "title": "Categorization regarding data protection act",
                                 "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
@@ -223,6 +240,7 @@
                                 ]
                             },
                             "bv:typeOfData": {
+				"required": true,
                                 "type": "string",
                                 "description": "Specifies the type of data (structured, unstructured, etc.).",
                                 "enum": [
@@ -233,21 +251,26 @@
                                 ]
                             },
                             "bv:archivalValue": {
+				"required": true,
                                 "type": "boolean",
                                 "description": "Indicates if this dataset has archival value."
                             },
                             "bv:opendata.swiss": {
+				"required": true,
                                 "type": "object",
                                 "description": "Reference to the Open Government Data publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
+					"required": true,
                                         "type": "boolean"
                                     },
                                     "dcterms:identifier": {
+					"required": false,
                                         "type": "string",
                                         "description": "Identifier for the OGD publication"
                                     },
                                     "dcat:accessURL": {
+					"required": false,
                                         "type": "string",
                                         "format": "uri",
                                         "description": "URL on opendata.swiss"
@@ -255,17 +278,21 @@
                                 }
                             },
 			    "bv:i14y": {
+				"required": true,
 				"type": "object",
                                 "description": "Reference to the I14Y publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
+					"required": true,
                                         "type": "boolean"
                                     },
                                     "dcterms:identifier": {
+					"required": false,
                                         "type": "string",
                                         "description": "Identifier for the I14Y publication"
                                     },
                                     "dcat:accessURL": {
+					"required": false,
                                         "type": "string",
                                         "format": "uri",
                                         "description": "URL on I14Y"
@@ -273,6 +300,7 @@
                                 }
 			    },
                             "dcat:themeTaxonomy": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Reference or URL to a theme taxonomy classification.",
                                 "items": {
@@ -286,19 +314,23 @@
                                 }
                             },
                             "dcat:landingPage": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "Landing page or homepage for the dataset."
                             },
                             "dcterms:spatial": {
+				"required": false,
                                 "type": "string",
                                 "description": "Spatial/geographical coverage."
                             },
                             "dcterms:temporal": {
+				"required": false,
                                 "type": "string",
                                 "description": "Temporal coverage of the dataset."
                             },
                             "bv:legalBasis": {
+				"required": false,
                                 "title": "Legal basis",
                                 "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
                                 "type": ["array","null"],
@@ -309,6 +341,7 @@
                                 }
                             },
                             "bv:businessProcess": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Related business process or context.",
                                 "items": {
@@ -316,14 +349,17 @@
                                 }
                             },
                             "bv:retentionPeriod": {
+				"required": false,
                                 "type": "integer",
                                 "description": "Retention period for the dataset."
                             },
                             "dcat:catalog": {
+				"required": false,
                                 "type": "string",
                                 "description": "Indicates which catalog this dataset belongs to."
                             },
                             "prov:wasDerivedFrom": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Source from which this dataset was derived.",
                                 "items": {
@@ -331,10 +367,12 @@
                                 }
                             },
                             "bv:geoIdentifier": {
+				"required": false,
                                 "type": "string",
                                 "description": "Geographical identifier (e.g., BFS numbers)."
                             },
                             "foaf:page": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Any related page or resource.",
                                 "items": {
@@ -343,23 +381,28 @@
                                 }
                             },
                             "bv:comments": {
+				"required": false,
                                 "type": "string",
                                 "description": "Additional comments about the dataset."
                             },
                             "bv:abrogation": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "description": "Indicates if the dataset was abrogated or replaced."
                             },
                             "bv:itSystem": {
+				"required": false,
                                 "type": "string",
                                 "description": "Name of the IT system managing this dataset."
                             },
                             "dcat:inSeries": {
+				"required": false,
                                 "type": "string",
                                 "description": "Reference to the series this dataset belongs to."
                             },
                             "dcterms:replaces": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "ID of datasets replaced by this one",
                                 "items": {
@@ -367,6 +410,7 @@
                                 }
                             },
                             "dcat:distribution": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Distribution info describing how and where to access the dataset.",
                                 "items": {
@@ -376,23 +420,20 @@
                                         "attributes": {
                                             "type": "object",
                                             "additionalProperties": false,
-                                            "required": [
-                                                "dcterms:identifier",
-                                                "dcat:accessURL",
-                                                "dcterms:title",
-                                                "dcterms:description"
-                                            ],
                                             "properties": {
                                                 "dcterms:identifier": {
+						    "required": true,
                                                     "type": "string",
                                                     "description": "Identifier for this distribution."
                                                 },
                                                 "dcat:accessURL": {
+						    "required": true,
                                                     "type": "string",
                                                     "format": "uri",
                                                     "description": "URL for accessing this distribution."
                                                 },
                                                 "adms:status": {
+						    "required": true,
                                                     "type": "string",
                                                     "description": "Status of this distribution (e.g., 'active', 'deprecated').",
                                                     "enum": [
@@ -404,20 +445,24 @@
                                                     ]
                                                 },
                                                 "dcterms:format": {
+						    "required": true,
                                                     "type": "string",
                                                     "description": "File format (e.g., CSV, JSON)."
                                                 },
                                                 "dcterms:modified": {
+						    "required": true,
                                                     "type": ["string", "null"],
                                                     "format": "date",
                                                     "description": "When the distribution file was last modified."
                                                 },
                                                 "dcat:downloadURL": {
+						    "required": false,
                                                     "type": ["string", "null"],
                                                     "format": "uri",
                                                     "description": "Download URL of the distribution file."
                                                 },
                                                 "dcterms:title": {
+						    "required": false,
                                                     "type": "object",
                                                     "description": "Title for the distribution, in multiple languages.",
                                                     "properties": {
@@ -440,32 +485,39 @@
                                                     }
                                                 },
                                                 "dcterms:description": {
+						    "required": false,
                                                     "type": "object",
                                                     "description": "Description for the distribution, in multiple languages.",
                                                     "properties": {
                                                         "de": {
+							    "required": false,
                                                             "type": "string",
                                                             "title": "Deutsch"
                                                         },
                                                         "fr": {
+							    "required": false,
                                                             "type": "string",
                                                             "title": "Français"
                                                         },
                                                         "it": {
+							    "required": false,
                                                             "type": "string",
                                                             "title": "Italiano"
                                                         },
                                                         "en": {
+							    "required": false,
                                                             "type": "string",
                                                             "title": "English"
                                                         }
                                                     }
                                                 },
                                                 "dcterms:conformsTo": {
+						    "required": false,
                                                     "type": "string",
                                                     "description": "Reference to a standard or specification the distribution conforms to."
                                                 },
                                                 "dcterms:license": {
+						    "required": false,
                                                     "type": "string",
                                                     "description": "License under which this distribution is released.",
                                                     "enum": [
@@ -477,10 +529,12 @@
                                                     ]
                                                 },
                                                 "bv:comments": {
+						    "required": false,
                                                     "type": "string",
                                                     "description": "Additional comments about the distribution."
                                                 },
                                                 "dcat:accessService": {
+						    "required": false,
                                                     "type": "string",
                                                     "description": "Indicates a service used to provide access to the data."
                                                 }
@@ -504,77 +558,87 @@
                     "attributes": {
                         "type": "object",
                         "description": "Descriptive attributes for the dataset series.",
-                        "required": [
-                            "dcterms:identifier",
-                            "dcterms:title",
-                            "bv:classification",
-                            "bv:personalData"
-                        ],
                         "properties": {
                             "imageURL": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                             },
 			    "dcterms:identifier": {
+				"required": true,
                                 "type": "string",
                                 "description": "Unique identifier for the dataset series."
                             },
                             "dcterms:title": {
+				"required": true,
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string"
                                     }
                                 }
                             },
                             "dcterms:description": {
+				"required": true,
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string"
                                     }
                                 }
                             },
                             "dcat:contactPoint": {
+				"required": true,
                                 "type": "object",
                                 "description": "Contact information for inquiries.",
                                 "properties": {
                                     "name": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "email": {
+					"required": true,
                                         "type": "string"
                                     }
-                                },
-                                "required": ["name", "email"]
+                                }
                             },
                             "dcterms:publisher": {
+				"required": true,
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the series."
                             },
                             "adms:status": {
+				"required": true,
                                 "type": "string",
                                 "description": "Current status of the dataset (sample enumeration).",
                                 "enum": [
@@ -586,6 +650,7 @@
                                 ]
                             },
                             "dcat:dataset": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Indicates which dataset(s) this series serves or is related to.",
                                 "items": {
@@ -593,6 +658,7 @@
                                 }
                             },
                             "foaf:page": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Any related page or resource.",
                                 "items": {
@@ -601,10 +667,12 @@
                                 }
                             },
                             "bv:comment": {
+				"required": false,
                                 "type": "string",
                                 "description": "Additional comments or notes about the series."
                             },
                             "dcat:keyword": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Keywords describing the dataset Serie.",
                                 "items": {
@@ -612,6 +680,7 @@
                                 }
                             },
                             "bv:classification": {
+				"required": true,
                                 "type": "string",
                                 "description": "Classification level of the dataset (sample enumeration).",
                                 "enum": [
@@ -622,6 +691,7 @@
                                 ]
                             },
                             "bv:personalData": {
+				"required": true,
                                 "type": "string",
                                 "description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
                                 "enum": [
@@ -645,72 +715,87 @@
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the DataService",
-                        "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
                         "properties": {
                             "imageURL": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                             },
 			    "dcterms:identifier": {
+				"required": true,
                                 "type": "string",
                                 "description": "Unique identifier for the DataService."
                             },
                             "dcterms:title": {
+				"required": true,
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string"
                                     }
                                 }
                             },
                             "dcterms:description": {
+				"required": true,
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
+				"required": true,
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the series."
                             },
                             "dcat:contactPoint": {
+				"required": true,
                                 "type": "object",
                                 "description": "Contact information for inquiries.",
                                 "properties": {
                                     "name": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "email": {
+					"required": true,
                                         "type": "string"
                                     }
-                                },
-                                "required": ["name", "email"]
+                                }
                             },
                             "dcterms:accessRights": {
+				"required": true,
                                 "type": "string",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [
@@ -722,11 +807,13 @@
                                 ]
                             },
                             "dcat:endopointURL": {
+				"required": true,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "URL of the service."
                             },
                             "adms:status": {
+				"required": true,
                                 "type": "string",
                                 "description": "Current status of the dataset (sample enumeration).",
                                 "enum": [
@@ -738,6 +825,7 @@
                                 ]
                             },
                             "dcat:servesDataset": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "IDs of the datasets served",
                                 "items": {
@@ -745,11 +833,13 @@
                                 }
                             },
                             "dcat:endpointDescription": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "URL of documentation."
                             },
                             "foaf:page": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "Any related page or resource.",
                                 "items": {
@@ -758,6 +848,7 @@
                                 }
                             },
                             "bv:comments": {
+				"required": false,
                                 "type": "string",
                                 "description": "Additional comments about the DataService."
                             }
@@ -776,72 +867,87 @@
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the Catalog",
-                        "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
                         "properties": {
                             "imageURL": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                             },
 			    "dcterms:identifier": {
+				"required": true,
                                 "type": "string",
                                 "description": "Unique identifier for the Catalog."
                             },
                             "dcterms:title": {
+				"required": true,
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string"
                                     }
                                 }
                             },
                             "dcterms:description": {
+				"required": true,
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "fr": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "it": {
+					"required": false,
                                         "type": "string"
                                     },
                                     "en": {
+					"required": false,
                                         "type": "string"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
+				"required": true,
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the series."
                             },
                             "dcat:contactPoint": {
+				"required": true,
                                 "type": "object",
                                 "description": "Contact information for inquiries.",
                                 "properties": {
                                     "name": {
+					"required": true,
                                         "type": "string"
                                     },
                                     "email": {
+					"required": true,
                                         "type": "string"
                                     }
-                                },
-                                "required": ["name", "email"]
+                                }
                             },
                             "dcterms:accessRights": {
+				"required": true,
                                 "type": "string",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [
@@ -853,11 +959,13 @@
                                 ]
                             },
                             "foaf:homepage": {
+				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "homepage for the catalog"
                             },
                             "dcat:dataset": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "IDs of the datasets in the catalog",
                                 "items": {
@@ -865,6 +973,7 @@
                                 }
                             },
                             "dcat:service": {
+				"required": false,
                                 "type": ["array","null"],
                                 "description": "IDs of the dataServices in the catalog",
                                 "items": {

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -916,7 +916,7 @@
 				"required": true,
                                 "type": "string",
                                 "title": "Access_rights",
-                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+                                "description": "Defines the accessibility of the DataService (e.g., public, internal, etc.).",
                                 "enum": [
                                     "CONFIDENTIAL",
                                     "NON_PUBLIC",
@@ -1002,94 +1002,111 @@
             "description": "container for dcat:Catalog",
             "items": {
                 "type": "object",
-                "description": "structure of Catalog",
+		"title": "catalog_objects",
+                "description": "Structure of Catalog. A catalog is a loose collection of Datasets, DatasetSeries and DataServices such as, for example, opendata.swiss or I14Y.",
                 "properties": {
                     "attributes": {
                         "type": "object",
-                        "description": "attributes for the Catalog",
+                        "description": "Attributes for the Catalog",
                         "properties": {
                             "imageURL": {
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
-                                "title": "Image URL",
+                                "title": "Image_URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                             },
 			    "dcterms:identifier": {
+				"title": "Catalog_id",
 				"required": true,
                                 "type": "string",
-                                "description": "Unique identifier for the Catalog."
+                                "description": "Identifier for this Catalog. If left empty, it will be automatically assigned."
                             },
                             "dcterms:title": {
+				"title": "Catalog_title",
 				"required": true,
                                 "type": "object",
-                                "description": "Title for the series in multiple languages.",
+                                "description": "Title for the Catalog in multiple languages.",
                                 "properties": {
                                     "de": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Deutsch"
                                     },
                                     "fr": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Français"
                                     },
                                     "it": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Italiano"
                                     },
                                     "en": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "English"
                                     }
                                 }
                             },
                             "dcterms:description": {
+				"title": "Catalog_description",
 				"required": true,
                                 "type": "object",
-                                "description": "Description for the series in multiple languages.",
+                                "description": "Description for the Catalog in multiple languages.",
                                 "properties": {
                                     "de": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Deutsch"
                                     },
                                     "fr": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Français"
                                     },
                                     "it": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Italiano"
                                     },
                                     "en": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "English"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
 				"required": true,
+				"title": "Publisher",
                                 "type": "string",
-                                "description": "Publisher or organization responsible for the series."
+                                "description": "Publisher or organization responsible for the Catalog."
                             },
                             "dcat:contactPoint": {
+				"title": "Contact_point",
+                                "description": "Contact information for potential inquiries about the Catalog.",
 				"required": true,
                                 "type": "object",
-                                "description": "Contact information for inquiries.",
                                 "properties": {
                                     "name": {
 					"required": true,
                                         "type": "string"
+					"title": "Name"
                                     },
                                     "email": {
 					"required": true,
                                         "type": "string"
+					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:accessRights": {
+				"title": "Access_rights",
 				"required": true,
                                 "type": "string",
-                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+                                "description": "Defines the accessibility of the Catalog (e.g., public, internal, etc.).",
                                 "enum": [
                                     "CONFIDENTIAL",
                                     "NON_PUBLIC",
@@ -1102,12 +1119,14 @@
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
-                                "description": "homepage for the catalog"
+				"title": "homepage",
+                                "description": "Homepage for the Catalog."
                             },
                             "dcat:dataset": {
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "IDs of the datasets in the catalog",
+				"title": "catalog_datasets",
+                                "description": "IDs of the datasets referenced in the Catalog.",
                                 "items": {
                                     "type": "string"
                                 }
@@ -1115,7 +1134,8 @@
                             "dcat:service": {
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "IDs of the dataServices in the catalog",
+				"title": "catalog_services",
+                                "description": "IDs of the DataServices referenced in the catalog",
                                 "items": {
                                     "type": "string"
                                 }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -14,12 +14,6 @@
                 "title": "Dataset_objects",
                 "description": "One item (i.e., one datset metadata) in the collection of datasets. This class describes a collection of homogeneous data characterized by its topic, process, infrastructure (including data processing and storage systems), purpose, and data type. A dataset is also consistent in terms of classification, the presence of personal data, and its degree of openness. Datasets are similar to products; they are prepared and made available to others under clearly defined usage criteria.",
                 "properties": {
-                    "attributes": {
-                        "type": "object",
-                        "additionalProperties": false,
-                        "title": "Dataset_metadata",
-                        "description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
-                        "properties": {
                             "schema:image": {
                                 "required": false,
 				"type": ["string", "null"],
@@ -466,10 +460,6 @@
                                     "type": "object",
                                     "additionalProperties": false,
                                     "properties": {
-                                        "attributes": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
                                                 "dcterms:identifier": {
 						    "title": "Distribution_id",
 						    "required": true,
@@ -603,14 +593,10 @@
                                                     "type": "string",
                                                     "description": "Reference to a service used to provide access to the data."
                                                 }
-                                            }
-                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                }
             }
         },
         "datasetSeries": {
@@ -621,10 +607,6 @@
 		"title": "datasetseries_objects",
                 "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01'). This class represents a collection of datasets that are published and can be used separately, but share some characteristics that group them.",
                 "properties": {
-                    "attributes": {
-                        "type": "object",
-                        "description": "Descriptive attributes for the dataset series.",
-                        "properties": {
                             "schema:image": {
 				"required": false,
                                 "type": ["string", "null"],
@@ -804,8 +786,6 @@
                                 ]
                             }
                         }
-                    }
-                }
             }
         },
         "dataServices": {
@@ -816,10 +796,6 @@
 		"title": "dataServices_objects",
                 "description": "A DataService represents a collection of operations accessible through an interface (API) that provide access to one or more datasets or data processing functions.",
                 "properties": {
-                    "attributes": {
-                        "type": "object",
-                        "description": "attributes for the DataService",
-                        "properties": {
                             "schema:image": {
 				"required": false,
                                 "type": ["string", "null"],
@@ -1020,8 +996,6 @@
                                         "description": "URL for the DataService on I14Y"
                                     }
                                 }
-			    }
-                        }
                     }
                 }
             }
@@ -1034,10 +1008,6 @@
 		"title": "catalog_objects",
                 "description": "Structure of Catalog. A catalog is a loose collection of Datasets, DatasetSeries and DataServices such as, for example, opendata.swiss or I14Y.",
                 "properties": {
-                    "attributes": {
-                        "type": "object",
-                        "description": "Attributes for the Catalog",
-                        "properties": {
                             "schema:image": {
 				"required": false,
                                 "type": ["string", "null"],
@@ -1169,8 +1139,6 @@
                                     "type": "string"
                                 }
                             }
-                        }
-                    }
                 }
             }
         }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -13,36 +13,7 @@
                 "type": "object",
                 "title": "Dataset metadata",
                 "description": "One item (i.e., one datset metadata) in the collection of datasets.",
-                "required": ["metadata", "attributes"],
                 "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "title": "Metadata about the dataset metadata (maybe meta-metadata?)",
-                        "description": "Metadata about the dataset, including last change date, user, etc.",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "title": "Last change date and time",
-                                "description": "Date and time when the dataset metadata was modified the last time."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "title": "Last change user",
-                                "description": "User that changed the dataset metadata for the last time."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "title": "Image URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
-                            }
-                        }
-                    },
                     "attributes": {
                         "type": "object",
                         "additionalProperties": false,
@@ -56,7 +27,13 @@
                             "bv:affiliatedPersons"
                         ],
                         "properties": {
-                            "dcterms:identifier": {
+                            "imageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "title": "Image URL",
+                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                            },
+			    "dcterms:identifier": {
                                 "type": "string",
                                 "title": "Dataset identifier",
                                 "description": "Unique identifier for the dataset."
@@ -277,8 +254,8 @@
                                     }
                                 }
                             },
-							"bv:i14y": {
-								"type": "object",
+			    "bv:i14y": {
+				"type": "object",
                                 "description": "Reference to the I14Y publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
@@ -294,7 +271,7 @@
                                         "description": "URL on I14Y"
                                     }
                                 }
-							},
+			    },
                             "dcat:themeTaxonomy": {
                                 "type": ["array","null"],
                                 "description": "Reference or URL to a theme taxonomy classification.",
@@ -395,7 +372,6 @@
                                 "items": {
                                     "type": "object",
                                     "additionalProperties": false,
-                                    "required": ["attributes"],
                                     "properties": {
                                         "attributes": {
                                             "type": "object",
@@ -524,32 +500,7 @@
             "items": {
                 "type": "object",
                 "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01').",
-                "required": ["metadata", "attributes"],
                 "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "description": "Metadata about the dataset series (last update date, user, image, etc.).",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Date/time when the series was last changed."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "description": "User or identifier who last updated the series."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL linking to an image for this series."
-                            }
-                        }
-                    },
                     "attributes": {
                         "type": "object",
                         "description": "Descriptive attributes for the dataset series.",
@@ -560,7 +511,13 @@
                             "bv:personalData"
                         ],
                         "properties": {
-                            "dcterms:identifier": {
+                            "imageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "title": "Image URL",
+                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                            },
+			    "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the dataset series."
                             },
@@ -684,38 +641,19 @@
             "items": {
                 "type": "object",
                 "description": "structure of DataService",
-                "required": ["metadata", "attributes"],
                 "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "description": "Metadata about the dataset series (last update date, user, image, etc.).",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Date/time when the series was last changed."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "description": "User or identifier who last updated the series."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL linking to an image for this series."
-                            }
-                        }
-                    },
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the DataService",
                         "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
                         "properties": {
-                            "dcterms:identifier": {
+                            "imageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "title": "Image URL",
+                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                            },
+			    "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the DataService."
                             },
@@ -834,38 +772,19 @@
             "items": {
                 "type": "object",
                 "description": "structure of Catalog",
-                "required": ["metadata", "attributes"],
                 "properties": {
-                    "metadata": {
-                        "type": "object",
-                        "description": "Metadata about the catalog (last update date, user, image, etc.).",
-                        "required": [
-                            "lastChangeDate",
-                            "lastChangeUser"
-                        ],
-                        "properties": {
-                            "lastChangeDate": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Date/time when the series was last changed."
-                            },
-                            "lastChangeUser": {
-                                "type": "string",
-                                "description": "User or identifier who last updated the series."
-                            },
-                            "imageURL": {
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL linking to an image for this series."
-                            }
-                        }
-                    },
                     "attributes": {
                         "type": "object",
                         "description": "attributes for the Catalog",
                         "required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint"],
                         "properties": {
-                            "dcterms:identifier": {
+                            "imageURL": {
+                                "type": ["string", "null"],
+                                "format": "uri",
+                                "title": "Image URL",
+                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                            },
+			    "dcterms:identifier": {
                                 "type": "string",
                                 "description": "Unique identifier for the Catalog."
                             },

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -297,9 +297,10 @@
                                 "properties": {
                                     "bv:mustBePublished": {
 					"title": "i14y_publication_flag",
-					"description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication.",
+					"description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
 					"required": true,
-                                        "type": "boolean"
+                                        "type": "boolean",
+					"default": true
                                     },
                                     "dcterms:identifier": {
 					"title": "i14y_id",
@@ -1000,9 +1001,10 @@
                                 "properties": {
                                     "bv:mustBePublished": {
 					"title": "i14y_publication_flag",
-					"description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication.",
+					"description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
 					"required": true,
-                                        "type": "boolean"
+                                        "type": "boolean",
+					"default": true
                                     },
                                     "dcterms:identifier": {
 					"title": "i14y_id",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -11,80 +11,83 @@
             "description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
             "items": {
                 "type": "object",
+		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:accessRights", "dcterms:publisher", "dcat:contactPoint", "dcterms:issued", "dcterms:accrualPeriodicity", "dcterms:modified", "schema:OrganizationRole", "adms:status", "bv:classification", "bv:personalData", "bv:archivalValue", "bv:opendata_swiss", "bv:i14y"],
                 "title": "Dataset_objects",
                 "description": "One item (i.e., one datset metadata) in the collection of datasets. This class describes a collection of homogeneous data characterized by its topic, process, infrastructure (including data processing and storage systems), purpose, and data type. A dataset is also consistent in terms of classification, the presence of personal data, and its degree of openness. Datasets are similar to products; they are prepared and made available to others under clearly defined usage criteria.",
                 "properties": {
                             "schema:image": {
-                                "required": false,
+                                
 				"type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image_URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the dataset's content."
                             },
 			    "dcterms:identifier": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Dataset_identifier",
                                 "description": "Unique identifier for the dataset. If left empty, it is automatically assigned."
                             },
                             "dcterms:title": {
-                                "required": true,
+                                
 				"type": "object",
+				"required": ["de", "fr"],
                                 "title": "Dataset_title",
                                 "description": "Title of the dataset.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
                                 }
                             },
                             "dcterms:description": {
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "title": "Dataset_description",
                                 "description": "Description of the dataset. Should go into details about the dataset content and help a non-specialist to understand what is the dataset about.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
                                 }
                             },
                             "dcterms:accessRights": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Access_rights",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
@@ -97,38 +100,39 @@
                                 ]
                             },
                             "dcterms:publisher": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Publisher",
                                 "description": "Entity (person or organization) who published the dataset."
                             },
                             "dcat:contactPoint": {
-				"required": true,
+				
                                 "type": "object",
+				"required": ["schema:name", "schema:email"],
                                 "title": "Contact_point",
                                 "description": "Contact information for potential inquiries about the dataset.",
                                 "properties": {
                                     "schema:name": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:issued": {
-				"required": true,
+				
                                 "title": "Issued_date",
                                 "description": "Date when the dataset was formally issued for the first time. If unknown, you may select the date of the first publication of this metadata.",
                                 "type": ["string", "null"],
                                 "format": "date"
                             },
                             "dcat:keyword": {
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "title": "Keywords",
                                 "description": "Keywords describing the dataset.",
@@ -137,7 +141,7 @@
                                 }
                             },
                             "dcterms:accrualPeriodicity": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Accrual_periodicity",
                                 "description": "Frequency with which dataset is updated (e.g., 'Annual').",
@@ -154,32 +158,33 @@
                                 ]
                             },
                             "dcterms:modified": {
-				"required": true,
+				
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "title": "Last_modification_date",
                                 "description": "Last modification date of the data in the dataset."
                             },
                             "schema:OrganizationRole": {
-				"required": true,
+				
                                 "type": "array",
                                 "title": "Affiliated_persons",
                                 "description": "List of affiliated people, their contact address and respective roles.",
                                 "items": {
                                     "type": "object",
+				    "required": ["schema:name", "schema:email", "schema:roleName"],
                                     "properties": {
                                         "schema:name": {
-					    "required": true,
+					    
                                             "type": "string",
 					    "title": "Name"
                                         },
                                         "schema:email": {
-					    "required": true,
+					    
                                             "type": "string",
 					    "title": "email"
                                         },
                                         "schema:roleName": {
-					    "required": true,
+					    
                                             "type": "string",
 					    "title": "Role",
                                             "description": "Role this person has for this dataset.",
@@ -196,14 +201,14 @@
                                     "type": "object",
                                     "properties": {
                                         "schema:roleName": {
-					    "required": true,
+					    
                                             "const": "dataOwner"
                                         }
                                     }
                                 }
                             },
                             "adms:status": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Status",
                                 "description": "Current status of the dataset.",
@@ -216,7 +221,7 @@
                                 ]
                             },
                             "bv:classification": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Classification_level",
                                 "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
@@ -228,7 +233,7 @@
                                 ]
                             },
                             "bv:personalData": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Categorization_DSG",
                                 "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
@@ -239,7 +244,7 @@
                                 ]
                             },
                             "bv:typeOfData": {
-				"required": false,
+				
                                 "type": "string",
 				"title": "Data_type",
                                 "description": "Specifies the type of data in the dataset (master data, reference data, thematic data or unstructured data).",
@@ -251,32 +256,33 @@
                                 ]
                             },
                             "bv:archivalValue": {
-				"required": true,
+				
                                 "type": "boolean",
 				"title": "Archival_value",
                                 "description": "Indicates if this dataset has archival value and must be sent to the BAR."
                             },
                             "bv:opendata_swiss": {
-				"required": true,
+				
                                 "type": "object",
+				"required": ["bv:mustBePublished"],
 				"title": "opendataswiss_publication",
                                 "description": "Indicates if the dataset must be published as Open Government Data (OGD) via the opendata.swiss portal. Optionally references the opendata.swiss publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
 					"title": "opendataswiss_publication_flag",
 					"description": "Indicates if the dataset must be published on opendata.swiss. May be used by harvesters or automatic metadata publication.",
-					"required": true,
+					
                                         "type": "boolean"
                                     },
                                     "dcterms:identifier": {
 					"title": "opendataswiss_id",
-					"required": false,
+					
                                         "type": "string",
                                         "description": "Identifier for the dataset on opendata.swiss."
                                     },
                                     "dcat:accessURL": {
 					"title": "opendataswiss_url",
-					"required": false,
+					
                                         "type": "string",
                                         "format": "uri",
                                         "description": "URL for the dataset on opendata.swiss"
@@ -284,27 +290,28 @@
                                 }
                             },
 			    "bv:i14y": {
-				"required": true,
+				
 				"type": "object",
+				"required": ["bv:mustBePublished"],
 				"title": "i14y_publication",
                                 "description": "Indicates if the dataset metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
 					"title": "i14y_publication_flag",
 					"description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
-					"required": true,
+					
                                         "type": "boolean",
 					"default": true
                                     },
                                     "dcterms:identifier": {
 					"title": "i14y_id",
-					"required": false,
+					
                                         "type": "string",
                                         "description": "Identifier for the dataset on I14Y."
                                     },
                                     "dcat:accessURL": {
 					"title": "i14y_url",
-					"required": false,
+					
                                         "type": "string",
                                         "format": "uri",
                                         "description": "URL for the dataset on I14Y"
@@ -312,7 +319,7 @@
                                 }
 			    },
                             "dcat:themeTaxonomy": {
-				"required": false,
+				
                                 "type": ["array","null"],
 				"title": "dataset_themes",
                                 "description": "This attribute classifies the dataset into one or more broad thematics. Proper classification allow other users interested in the topic to find the dataset without knowing its name or description.",
@@ -328,25 +335,25 @@
                             },
                             "dcat:landingPage": {
 				"title": "Landing_page",
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "Landing page or homepage for the dataset."
                             },
                             "dcterms:spatial": {
 				"title": "spatial_coverage",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Spatial/geographical coverage of the dataset."
                             },
                             "dcterms:temporal": {
 				"title": "temporal_coverage",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Temporal coverage of the dataset. For example, the first and last measurement years for a timeseries."
                             },
                             "dpv:hasLegalBasis": {
-				"required": false,
+				
                                 "title": "Legal_basis",
                                 "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
                                 "type": ["array","null"],
@@ -358,7 +365,7 @@
                             },
                             "bv:businessProcess": {
 				"title": "business_process",
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "description": "Related business process or context.",
                                 "items": {
@@ -367,19 +374,19 @@
                             },
                             "bv:retentionPeriod": {
 				"title": "retention_period",
-				"required": false,
+				
                                 "type": "integer",
                                 "description": "Retention period for the dataset. That is, the time that the dataset must legally be available after the end of its active use."
                             },
                             "dcat:catalog": {
 				"title": "catalog",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Indicates in which catalog this dataset is available."
                             },
                             "prov:wasDerivedFrom": {
 				"title": "derived_from",
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "description": "Links to other datasets from which this dataset was derived.",
                                 "items": {
@@ -388,29 +395,30 @@
                             },
                             "bv:geoIdentifier": {
 				"title": "geo_identifier",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Identifier for the dataset according to the GeoIV."
                             },
 			    "foaf:page": {
-				"required": false,
+				
     				"type": ["array","null"],
     				"title": "Related_resources",
     				"description": "Any related page, document or resource.",
 				"items": {
 					"type": "object",
+					"required": ["uri"],
         				"additionalProperties": false,
         				"properties": {
 					     "alias": {
 						"title": "page_alias",
 						"description": "Alias to be showed in the interface for this link.",
-						"required": false,
+						
 						"type": "string"
 					    },
 					    "uri": {
 						"title": "url",
 						"description": "URL for the page, document or resource",
-						"required": true,
+						
 						"type": ["string", "null"],
                 				"format": "uri"
 					    }
@@ -419,32 +427,32 @@
 			    },
                             "schema:comment": {
 				"title": "comments",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Additional comments about the dataset."
                             },
                             "bv:abrogation": {
 				"title": "abrogation",
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "description": "Indicates when the dataset was abrogated or replaced."
                             },
                             "bv:itSystem": {
 				"title": "it_system",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Name of the IT system managing this dataset."
                             },
                             "dcat:inSeries": {
 				"title": "in_series",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Reference to the series this dataset belongs to."
                             },
                             "dcterms:replaces": {
 				"title": "replaces",
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "description": "ID of datasets replaced by this one",
                                 "items": {
@@ -452,30 +460,31 @@
                                 }
                             },
                             "dcat:distribution": {
-				"required": false,
+				
                                 "type": ["array","null"],
 				"title": "Distribution",
                                 "description": "Distribution info describing how and where to access the dataset. This class describes a specific, final, and ready-to-use format in which a dataset is made available to users. For example, the same data may be available as both a CSV file and an Excel file, each representing a separate distribution of the same dataset. Each distribution must be part of a dataset and should point to a reachable source (e.g. an URL for download). All distributions within a dataset must maintain the same level of timeliness across all channels. This means, for instance, that the 2021 CSV file should be published simultaneously with the Excel file, and vice versa.",
                                 "items": {
                                     "type": "object",
+				    "required": ["dcterms:identifier", "dcat:accessURL", "adms:status", "dcterms:format", "dcterms:modified"],
                                     "additionalProperties": false,
                                     "properties": {
                                                 "dcterms:identifier": {
 						    "title": "Distribution_id",
-						    "required": true,
+						    
                                                     "type": "string",
                                                     "description": "Identifier for this distribution. If left empty, it will be automatically assigned."
                                                 },
                                                 "dcat:accessURL": {
 						    "title": "access_url",
-						    "required": true,
+						    
                                                     "type": "string",
                                                     "format": "uri",
                                                     "description": "URL to a page for accessing this distribution. This must not be a direct download URL but, for example, a link to a webpage containing download links."
                                                 },
                                                 "adms:status": {
 						    "title": "Status",
-						    "required": true,
+						    
                                                     "type": "string",
                                                     "description": "Current status of the distribution.",
                                                     "enum": [
@@ -488,47 +497,48 @@
                                                 },
                                                 "dcterms:format": {
 						    "title": "format",
-						    "required": true,
+						    
                                                     "type": "string",
                                                     "description": "File format for this distribution (e.g., CSV, JSON)."
                                                 },
                                                 "dcterms:modified": {
 						    "title": "Last_modification_date",
-						    "required": true,
+						    
                                                     "type": ["string", "null"],
                                                     "format": "date",
                                                     "description": "Last modification date of the data in this distribution."
                                                 },
                                                 "dcat:downloadURL": {
 						    "title": "download_url",
-						    "required": false,
+						    
                                                     "type": ["string", "null"],
                                                     "format": "uri",
                                                     "description": "Direct download URL of the distribution file. This link must directly point to the file."
                                                 },
                                                 "dcterms:title": {
 						    "title": "Distribution_title",
-						    "required": false,
+						    
                                                     "type": "object",
+						    "required": ["de", "fr"],
                                                     "description": "Title for the distribution, in multiple languages.",
                                                     "properties": {
                                                         "de": {
-							    "required": true,
+							    
                                                             "type": "string",
                                                             "title": "Deutsch"
                                                         },
                                                         "fr": {
-							    "required": true,
+							    
                                                             "type": "string",
                                                             "title": "Français"
                                                         },
                                                         "it": {
-							    "required": false,
+							    
                                                             "type": "string",
                                                             "title": "Italiano"
                                                         },
                                                         "en": {
-							    "required": false,
+							    
                                                             "type": "string",
                                                             "title": "English"
                                                         }
@@ -536,27 +546,28 @@
                                                 },
                                                 "dcterms:description": {
 						    "title": "Distribution_description",
-						    "required": false,
+						    
                                                     "type": "object",
+						    "required": ["de", "fr"],
                                                     "description": "Description for the distribution, in multiple languages.",
                                                     "properties": {
                                                         "de": {
-							    "required": true,
+							    
                                                             "type": "string",
                                                             "title": "Deutsch"
                                                         },
                                                         "fr": {
-							    "required": true,
+							    
                                                             "type": "string",
                                                             "title": "Français"
                                                         },
                                                         "it": {
-							    "required": false,
+							    
                                                             "type": "string",
                                                             "title": "Italiano"
                                                         },
                                                         "en": {
-							    "required": false,
+							    
                                                             "type": "string",
                                                             "title": "English"
                                                         }
@@ -564,13 +575,13 @@
                                                 },
                                                 "dcterms:conformsTo": {
 						    "title": "conforms_to",
-						    "required": false,
+						    
                                                     "type": "string",
                                                     "description": "Reference to a standard or specification the distribution conforms to."
                                                 },
                                                 "dcterms:license": {
 						    "title": "license",
-						    "required": false,
+						    
                                                     "type": "string",
                                                     "description": "License under which this distribution is released. This is mandatory for opendata.swiss publications.",
                                                     "enum": [
@@ -583,13 +594,13 @@
                                                 },
                                                 "schema:comment": {
 						    "title": "comments",
-						    "required": false,
+						    
                                                     "type": "string",
                                                     "description": "Additional comments about the distribution."
                                                 },
                                                 "dcat:accessService": {
 						    "title": "access_service",
-						    "required": false,
+						    
                                                     "type": "string",
                                                     "description": "Reference to a service used to provide access to the data."
                                                 }
@@ -604,11 +615,12 @@
             "description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
             "items": {
                 "type": "object",
+		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcat:contactPoint", "dcterms:publisher", "adms:status", "bv:classification", "bv:personalData"],
 		"title": "datasetseries_objects",
                 "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01'). This class represents a collection of datasets that are published and can be used separately, but share some characteristics that group them.",
                 "properties": {
                             "schema:image": {
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image_URL",
@@ -616,33 +628,34 @@
                             },
 			    "dcterms:identifier": {
 				"title": "Series_id",
-				"required": true,
+				
                                 "type": "string",
                                 "description": "Identifier for this DatasetSeries. If left empty, it will be automatically assigned."
                             },
                             "dcterms:title": {
 				"title": "Series_title",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
@@ -650,27 +663,28 @@
                             },
                             "dcterms:description": {
 				"title": "Series_description",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
@@ -679,30 +693,31 @@
                             "dcat:contactPoint": {
 				"title": "Contact_point",
                                 "description": "Contact information for potential inquiries about the DatasetSeries.",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["schema:name", "schema:email"],
                                 "properties": {
                                     "schema:name": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
-				"required": true,
+				
                                 "type": "string",
 				"title": "Publisher",
                                 "description": "Publisher or organization responsible for the series."
                             },
                             "adms:status": {
 				"title": "Status",
-				"required": true,
+				
                                 "type": "string",
                                 "description": "Current status of the DatasetSeries.",
                                 "enum": [
@@ -715,7 +730,7 @@
                             },
                             "dcat:dataset": {
 				"title": "series_dataset",
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "description": "References which dataset(s) are grouped within this DatasetSeries. Please note that a Dataset may be referenced by multiple DatasetSeries.",
                                 "items": {
@@ -723,24 +738,25 @@
                                 }
                             },
 			    "foaf:page": {
-				"required": false,
+				
     				"type": ["array","null"],
     				"title": "Related_resources",
     				"description": "Any related page, document or resource.",
 				"items": {
 					"type": "object",
+					"required": ["uri"],
         				"additionalProperties": false,
         				"properties": {
 					     "alias": {
 						"title": "page_alias",
 						"description": "Alias to be showed in the interface for this link.",
-						"required": false,
+						
 						"type": "string"
 					    },
 					    "uri": {
 						"title": "url",
 						"description": "URL for the page, document or resource",
-						"required": true,
+						
 						"type": ["string", "null"],
                 				"format": "uri"
 					    }
@@ -749,12 +765,12 @@
 			    },
                             "schema:comment": {
 				"title": "comments",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Additional comments or notes about the DatasetSeries."
                             },
                             "dcat:keyword": {
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "title": "Keywords",
                                 "description": "Keywords describing the DatasetSeries.",
@@ -763,7 +779,7 @@
                                 }
                             },
                             "bv:classification": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Classification_level",
                                 "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
@@ -775,7 +791,7 @@
                                 ]
                             },
                             "bv:personalData": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Categorization_DSG",
                                 "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
@@ -793,11 +809,12 @@
             "description": "Container for dcat:DataService",
             "items": {
                 "type": "object",
+		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint", "dcterms:accessRights", "dcat:endopointURL", "adms:status"],
 		"title": "dataServices_objects",
                 "description": "A DataService represents a collection of operations accessible through an interface (API) that provide access to one or more datasets or data processing functions.",
                 "properties": {
                             "schema:image": {
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image_URL",
@@ -805,33 +822,34 @@
                             },
 			    "dcterms:identifier": {
 				"title": "Service_id",
-				"required": true,
+				
                                 "type": "string",
                                 "description": "Identifier for this DataService. If left empty, it will be automatically assigned."
                             },
                             "dcterms:title": {
 				"title": "dataService_title",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "description": "Title for the DataService in multiple languages.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
@@ -839,34 +857,35 @@
                             },
                             "dcterms:description": {
 				"title": "dataService_description",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Publisher",
                                 "description": "Publisher or organization responsible for the DataService."
@@ -874,23 +893,24 @@
                             "dcat:contactPoint": {
 				"title": "Contact_point",
                                 "description": "Contact information for potential inquiries about the DataService.",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["schema:name", "schema:email"],
                                 "properties": {
                                     "schema:name": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:accessRights": {
-				"required": true,
+				
                                 "type": "string",
                                 "title": "Access_rights",
                                 "description": "Defines the accessibility of the DataService (e.g., public, internal, etc.).",
@@ -904,14 +924,14 @@
                             },
                             "dcat:endopointURL": {
 				"title": "endpoint_url",
-				"required": true,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "URL of the technical endpoint of the DataService."
                             },
                             "adms:status": {
 				"title": "Status",
-				"required": true,
+				
                                 "type": "string",
                                 "description": "Current status of the DataService.",
                                 "enum": [
@@ -924,7 +944,7 @@
                             },
                             "dcat:servesDataset": {
 				"title": "serves_dataset",
-				"required": false,
+				
                                 "type": ["array","null"],
                                 "description": "IDs of the datasets served by this DataService",
                                 "items": {
@@ -933,30 +953,31 @@
                             },
                             "dcat:endpointDescription": {
 				"title": "endpoint_description",
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "URL of technical documentation of the DataService, such as for example a Swagger documentation."
                             },
 			    "foaf:page": {
-				"required": false,
+				
     				"type": ["array","null"],
     				"title": "Related_resources",
     				"description": "Any related page, document or resource.",
 				"items": {
 					"type": "object",
+					"required": ["uri"],
         				"additionalProperties": false,
         				"properties": {
 					     "alias": {
 						"title": "page_alias",
 						"description": "Alias to be showed in the interface for this link.",
-						"required": false,
+						
 						"type": "string"
 					    },
 					    "uri": {
 						"title": "url",
 						"description": "URL for the page, document or resource",
-						"required": true,
+						
 						"type": ["string", "null"],
                 				"format": "uri"
 					    }
@@ -965,32 +986,33 @@
 			    },
                             "schema:comment": {
 				"title": "comments",
-				"required": false,
+				
                                 "type": "string",
                                 "description": "Additional comments about the DataService."
                             },
 			    "bv:i14y": {
-				"required": true,
+				
 				"type": "object",
+				"required": ["bv:mustBePublished"],
 				"title": "i14y_publication",
                                 "description": "Indicates if the DataService metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
 					"title": "i14y_publication_flag",
 					"description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
-					"required": true,
+					
                                         "type": "boolean",
 					"default": true
                                     },
                                     "dcterms:identifier": {
 					"title": "i14y_id",
-					"required": false,
+					
                                         "type": "string",
                                         "description": "Identifier for the DataService on I14Y."
                                     },
                                     "dcat:accessURL": {
 					"title": "i14y_url",
-					"required": false,
+					
                                         "type": "string",
                                         "format": "uri",
                                         "description": "URL for the DataService on I14Y"
@@ -1005,11 +1027,12 @@
             "description": "container for dcat:Catalog",
             "items": {
                 "type": "object",
+		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint", "dcterms:accessRights"],
 		"title": "catalog_objects",
                 "description": "Structure of Catalog. A catalog is a loose collection of Datasets, DatasetSeries and DataServices such as, for example, opendata.swiss or I14Y.",
                 "properties": {
                             "schema:image": {
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "title": "Image_URL",
@@ -1017,33 +1040,34 @@
                             },
 			    "dcterms:identifier": {
 				"title": "Catalog_id",
-				"required": true,
+				
                                 "type": "string",
                                 "description": "Identifier for this Catalog. If left empty, it will be automatically assigned."
                             },
                             "dcterms:title": {
 				"title": "Catalog_title",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "description": "Title for the Catalog in multiple languages.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
@@ -1051,34 +1075,35 @@
                             },
                             "dcterms:description": {
 				"title": "Catalog_description",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["de", "fr"],
                                 "description": "Description for the Catalog in multiple languages.",
                                 "properties": {
                                     "de": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Deutsch"
                                     },
                                     "fr": {
-					"required": true,
+					
                                         "type": "string",
                                         "title": "Français"
                                     },
                                     "it": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "Italiano"
                                     },
                                     "en": {
-					"required": false,
+					
                                         "type": "string",
                                         "title": "English"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
-				"required": true,
+				
 				"title": "Publisher",
                                 "type": "string",
                                 "description": "Publisher or organization responsible for the Catalog."
@@ -1086,16 +1111,17 @@
                             "dcat:contactPoint": {
 				"title": "Contact_point",
                                 "description": "Contact information for potential inquiries about the Catalog.",
-				"required": true,
+				
                                 "type": "object",
+				"required": ["schema:name", "schema:email"],
                                 "properties": {
                                     "schema:name": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
-					"required": true,
+					
                                         "type": "string",
 					"title": "email"
                                     }
@@ -1103,7 +1129,7 @@
                             },
                             "dcterms:accessRights": {
 				"title": "Access_rights",
-				"required": true,
+				
                                 "type": "string",
                                 "description": "Defines the accessibility of the Catalog (e.g., public, internal, etc.).",
                                 "enum": [
@@ -1115,14 +1141,14 @@
                                 ]
                             },
                             "foaf:homepage": {
-				"required": false,
+				
                                 "type": ["string", "null"],
                                 "format": "uri",
 				"title": "homepage",
                                 "description": "Homepage for the Catalog."
                             },
                             "dcat:dataset": {
-				"required": false,
+				
                                 "type": ["array","null"],
 				"title": "catalog_datasets",
                                 "description": "IDs of the datasets referenced in the Catalog.",
@@ -1131,7 +1157,7 @@
                                 }
                             },
                             "dcat:service": {
-				"required": false,
+				
                                 "type": ["array","null"],
 				"title": "catalog_services",
                                 "description": "IDs of the DataServices referenced in the catalog",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -116,7 +116,7 @@
                                 "properties": {
                                     "schema:name": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
@@ -393,7 +393,7 @@
                                 }
                             },
                             "bv:geoIdentifier": {
-				"title": "geo_identifier"
+				"title": "geo_identifier",
 				"required": false,
                                 "type": "string",
                                 "description": "Identifier for the dataset according to the GeoIV."
@@ -437,7 +437,7 @@
                                 "description": "Indicates when the dataset was abrogated or replaced."
                             },
                             "bv:itSystem": {
-				"title": "it_system"
+				"title": "it_system",
 				"required": false,
                                 "type": "string",
                                 "description": "Name of the IT system managing this dataset."
@@ -707,7 +707,7 @@
                                     },
                                     "schema:email": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
 					"title": "email"
                                     }
                                 }
@@ -903,12 +903,12 @@
                                 "properties": {
                                     "schema:name": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
 					"title": "email"
                                     }
                                 }
@@ -1121,12 +1121,12 @@
                                 "properties": {
                                     "schema:name": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
 					"title": "Name"
                                     },
                                     "schema:email": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
 					"title": "email"
                                     }
                                 }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -371,15 +371,27 @@
                                 "type": "string",
                                 "description": "Geographical identifier (e.g., BFS numbers)."
                             },
-                            "foaf:page": {
+			    "foaf:page": {
 				"required": false,
-                                "type": ["array","null"],
-                                "description": "Any related page or resource.",
-                                "items": {
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
+    				"type": ["array","null"],
+    				"title": "Related resources",
+    				"description": "Any related page or resource.",
+				"items": {
+					"type": "object",
+        				"additionalProperties": false,
+        				"properties": {
+					     "alias": {
+						"required": false,
+						"type": "string"
+					    },
+					    "uri": {
+						"required": true,
+						"type": ["string", "null"],
+                				"format": "uri"
+					    }
+	    			       }
+				 }
+			    },
                             "bv:comments": {
 				"required": false,
                                 "type": "string",
@@ -657,15 +669,27 @@
                                     "type": "string"
                                 }
                             },
-                            "foaf:page": {
+			    "foaf:page": {
 				"required": false,
-                                "type": ["array","null"],
-                                "description": "Any related page or resource.",
-                                "items": {
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
+    				"type": ["array","null"],
+    				"title": "Related resources",
+    				"description": "Any related page or resource.",
+				"items": {
+					"type": "object",
+        				"additionalProperties": false,
+        				"properties": {
+					     "alias": {
+						"required": false,
+						"type": "string"
+					    },
+					    "uri": {
+						"required": true,
+						"type": ["string", "null"],
+                				"format": "uri"
+					    }
+	    			       }
+				 }
+			    },
                             "bv:comment": {
 				"required": false,
                                 "type": "string",
@@ -838,15 +862,27 @@
                                 "format": "uri",
                                 "description": "URL of documentation."
                             },
-                            "foaf:page": {
+			    "foaf:page": {
 				"required": false,
-                                "type": ["array","null"],
-                                "description": "Any related page or resource.",
-                                "items": {
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
+    				"type": ["array","null"],
+    				"title": "Related resources",
+    				"description": "Any related page or resource.",
+				"items": {
+					"type": "object",
+        				"additionalProperties": false,
+        				"properties": {
+					     "alias": {
+						"required": false,
+						"type": "string"
+					    },
+					    "uri": {
+						"required": true,
+						"type": ["string", "null"],
+                				"format": "uri"
+					    }
+	    			       }
+				 }
+			    },
                             "bv:comments": {
 				"required": false,
                                 "type": "string",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -812,7 +812,8 @@
             "description": "Container for dcat:DataService",
             "items": {
                 "type": "object",
-                "description": "structure of DataService",
+		"title": "dataServices_objects",
+                "description": "A DataService represents a collection of operations accessible through an interface (API) that provide access to one or more datasets or data processing functions.",
                 "properties": {
                     "attributes": {
                         "type": "object",
@@ -822,83 +823,99 @@
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
-                                "title": "Image URL",
+                                "title": "Image_URL",
                                 "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                             },
 			    "dcterms:identifier": {
+				"title": "Service_id",
 				"required": true,
                                 "type": "string",
-                                "description": "Unique identifier for the DataService."
+                                "description": "Identifier for this DataService. If left empty, it will be automatically assigned."
                             },
                             "dcterms:title": {
+				"title": "dataService_title",
 				"required": true,
                                 "type": "object",
-                                "description": "Title for the series in multiple languages.",
+                                "description": "Title for the DataService in multiple languages.",
                                 "properties": {
                                     "de": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Deutsch"
                                     },
                                     "fr": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Français"
                                     },
                                     "it": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Italiano"
                                     },
                                     "en": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "English"
                                     }
                                 }
                             },
                             "dcterms:description": {
+				"title": "dataService_description",
 				"required": true,
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Deutsch"
                                     },
                                     "fr": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Français"
                                     },
                                     "it": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Italiano"
                                     },
                                     "en": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "English"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
 				"required": true,
                                 "type": "string",
-                                "description": "Publisher or organization responsible for the series."
+                                "title": "Publisher",
+                                "description": "Publisher or organization responsible for the DataService."
                             },
                             "dcat:contactPoint": {
+				"title": "Contact_point",
+                                "description": "Contact information for potential inquiries about the DataService.",
 				"required": true,
                                 "type": "object",
-                                "description": "Contact information for inquiries.",
                                 "properties": {
                                     "name": {
 					"required": true,
                                         "type": "string"
+					"title": "Name"
                                     },
                                     "email": {
 					"required": true,
                                         "type": "string"
+					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:accessRights": {
 				"required": true,
                                 "type": "string",
+                                "title": "Access_rights",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [
                                     "CONFIDENTIAL",
@@ -909,15 +926,17 @@
                                 ]
                             },
                             "dcat:endopointURL": {
+				"title": "endpoint_url",
 				"required": true,
                                 "type": ["string", "null"],
                                 "format": "uri",
-                                "description": "URL of the service."
+                                "description": "URL of the technical endpoint of the DataService."
                             },
                             "adms:status": {
+				"title": "Status",
 				"required": true,
                                 "type": "string",
-                                "description": "Current status of the dataset (sample enumeration).",
+                                "description": "Current status of the DataService.",
                                 "enum": [
                                     "workInProgress",
                                     "validated",
@@ -927,33 +946,39 @@
                                 ]
                             },
                             "dcat:servesDataset": {
+				"title": "serves_dataset",
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "IDs of the datasets served",
+                                "description": "IDs of the datasets served by this DataService",
                                 "items": {
                                     "type": "string"
                                 }
                             },
                             "dcat:endpointDescription": {
+				"title": "endpoint_description",
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
-                                "description": "URL of documentation."
+                                "description": "URL of technical documentation of the DataService, such as for example a Swagger documentation."
                             },
 			    "foaf:page": {
 				"required": false,
     				"type": ["array","null"],
-    				"title": "Related resources",
-    				"description": "Any related page or resource.",
+    				"title": "Related_resources",
+    				"description": "Any related page, document or resource.",
 				"items": {
 					"type": "object",
         				"additionalProperties": false,
         				"properties": {
 					     "alias": {
+						"title": "page_alias",
+						"description": "Alias to be showed in the interface for this link.",
 						"required": false,
 						"type": "string"
 					    },
 					    "uri": {
+						"title": "url",
+						"description": "URL for the page, document or resource",
 						"required": true,
 						"type": ["string", "null"],
                 				"format": "uri"
@@ -962,6 +987,7 @@
 				 }
 			    },
                             "bv:comments": {
+				"title": "comments",
 				"required": false,
                                 "type": "string",
                                 "description": "Additional comments about the DataService."

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -11,32 +11,32 @@
             "description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
             "items": {
                 "type": "object",
-                "title": "Dataset metadata",
-                "description": "One item (i.e., one datset metadata) in the collection of datasets.",
+                "title": "Dataset_objects",
+                "description": "One item (i.e., one datset metadata) in the collection of datasets. This class describes a collection of homogeneous data characterized by its topic, process, infrastructure (including data processing and storage systems), purpose, and data type. A dataset is also consistent in terms of classification, the presence of personal data, and its degree of openness. Datasets are similar to products; they are prepared and made available to others under clearly defined usage criteria.",
                 "properties": {
                     "attributes": {
                         "type": "object",
                         "additionalProperties": false,
-                        "title": "Dataset metadata",
+                        "title": "Dataset_metadata",
                         "description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
                         "properties": {
                             "imageURL": {
                                 "required": false,
 				"type": ["string", "null"],
                                 "format": "uri",
-                                "title": "Image URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                                "title": "Image_URL",
+                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the dataset's content."
                             },
 			    "dcterms:identifier": {
 				"required": true,
                                 "type": "string",
-                                "title": "Dataset identifier",
-                                "description": "Unique identifier for the dataset."
+                                "title": "Dataset_identifier",
+                                "description": "Unique identifier for the dataset. If left empty, it is automatically assigned."
                             },
                             "dcterms:title": {
                                 "required": true,
 				"type": "object",
-                                "title": "Title",
+                                "title": "Dataset_title",
                                 "description": "Title of the dataset.",
                                 "properties": {
                                     "de": {
@@ -64,8 +64,8 @@
                             "dcterms:description": {
 				"required": true,
                                 "type": "object",
-                                "title": "Description",
-                                "description": "Description of the dataset. May go into details about the dataset content.",
+                                "title": "Dataset_description",
+                                "description": "Description of the dataset. Should go into details about the dataset content and help a non-specialist to understand what is the dataset about.",
                                 "properties": {
                                     "de": {
 					"required": true,
@@ -92,7 +92,7 @@
                             "dcterms:accessRights": {
 				"required": true,
                                 "type": "string",
-                                "title": "Access rights",
+                                "title": "Access_rights",
                                 "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                                 "enum": [
                                     "CONFIDENTIAL",
@@ -106,28 +106,30 @@
 				"required": true,
                                 "type": "string",
                                 "title": "Publisher",
-                                "description": "Name of the entity (person or organization) who published the dataset."
+                                "description": "Entity (person or organization) who published the dataset."
                             },
                             "dcat:contactPoint": {
 				"required": true,
                                 "type": "object",
-                                "title": "Contact point",
-                                "description": "Contact information for potential inquiries abou the dataset.",
+                                "title": "Contact_point",
+                                "description": "Contact information for potential inquiries about the dataset.",
                                 "properties": {
                                     "name": {
 					"required": true,
                                         "type": "string"
+					"title": "Name"
                                     },
                                     "email": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:issued": {
 				"required": true,
-                                "title": "Issued date",
-                                "description": "Date when the dataset was formally issued.",
+                                "title": "Issued_date",
+                                "description": "Date when the dataset was formally issued for the first time. If unknown, you may select the date of the first publication of this metadata.",
                                 "type": ["string", "null"],
                                 "format": "date"
                             },
@@ -143,7 +145,7 @@
                             "dcterms:accrualPeriodicity": {
 				"required": true,
                                 "type": "string",
-                                "title": "Accrual periodicity",
+                                "title": "Accrual_periodicity",
                                 "description": "Frequency with which dataset is updated (e.g., 'Annual').",
                                 "enum": [
                                     "OTHER",
@@ -161,29 +163,32 @@
 				"required": true,
                                 "type": ["string", "null"],
                                 "format": "date",
-                                "title": "Last modification date",
-                                "description": "Last modification date of the dataset (not to be confused with the dataset metadata)."
+                                "title": "Last_modification_date",
+                                "description": "Last modification date of the data in the dataset (not to be confused with the dataset metadata)."
                             },
                             "bv:affiliatedPersons": {
 				"required": true,
                                 "type": "array",
-                                "title": "Affiliated person(s)",
+                                "title": "Affiliated_persons",
                                 "description": "List of affiliated people, their contact address and respective roles.",
                                 "items": {
                                     "type": "object",
                                     "properties": {
                                         "name": {
 					    "required": true,
-                                            "type": "string"
+                                            "type": "string",
+					    "title": "Name"
                                         },
                                         "email": {
 					    "required": true,
-                                            "type": "string"
+                                            "type": "string",
+					    "title": "email"
                                         },
                                         "role": {
 					    "required": true,
                                             "type": "string",
-                                            "description": "role",
+					    "title": "Role",
+                                            "description": "Role this person has for this dataset.",
                                             "enum": [
                                                 "dataOwner",
                                                 "dataSteward",
@@ -207,7 +212,7 @@
 				"required": true,
                                 "type": "string",
                                 "title": "Status",
-                                "description": "Current status of the dataset (sample enumeration).",
+                                "description": "Current status of the dataset.",
                                 "enum": [
                                     "workInProgress",
                                     "validated",
@@ -219,8 +224,8 @@
                             "bv:classification": {
 				"required": true,
                                 "type": "string",
-                                "title": "Classification level",
-                                "description": "Classification level of the dataset (sample enumeration).",
+                                "title": "Classification_level",
+                                "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
                                 "enum": [
                                     "none",
                                     "internal",
@@ -231,7 +236,7 @@
                             "bv:personalData": {
 				"required": true,
                                 "type": "string",
-                                "title": "Categorization regarding data protection act",
+                                "title": "Categorization_DSG",
                                 "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
                                 "enum": [
                                     "none",
@@ -240,9 +245,10 @@
                                 ]
                             },
                             "bv:typeOfData": {
-				"required": true,
+				"required": false,
                                 "type": "string",
-                                "description": "Specifies the type of data (structured, unstructured, etc.).",
+				"title": "Data_type",
+                                "description": "Specifies the type of data in the dataset (master data, reference data, thematic data or unstructured data).",
                                 "enum": [
                                     "thematicData",
                                     "referenceData",
@@ -253,56 +259,68 @@
                             "bv:archivalValue": {
 				"required": true,
                                 "type": "boolean",
-                                "description": "Indicates if this dataset has archival value."
+				"title": "Archival_value",
+                                "description": "Indicates if this dataset has archival value and must be sent to the BAR."
                             },
-                            "bv:opendata.swiss": {
+                            "bv:opendata_swiss": {
 				"required": true,
                                 "type": "object",
-                                "description": "Reference to the Open Government Data publication ID.",
+				"title": "opendataswiss_publication",
+                                "description": "Indicates if the dataset must be published as Open Government Data (OGD) via the opendata.swiss portal. Optionally references the opendata.swiss publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
+					"title": "opendataswiss_publication_flag",
+					"description": "Indicates if the dataset must be published on opendata.swiss. May be used by harvesters or automatic metadata publication.",
 					"required": true,
                                         "type": "boolean"
                                     },
                                     "dcterms:identifier": {
+					"title": "opendataswiss_id",
 					"required": false,
                                         "type": "string",
-                                        "description": "Identifier for the OGD publication"
+                                        "description": "Identifier for the dataset on opendata.swiss."
                                     },
                                     "dcat:accessURL": {
+					"title": "opendataswiss_url",
 					"required": false,
                                         "type": "string",
                                         "format": "uri",
-                                        "description": "URL on opendata.swiss"
+                                        "description": "URL for the dataset on opendata.swiss"
                                     }
                                 }
                             },
 			    "bv:i14y": {
 				"required": true,
 				"type": "object",
-                                "description": "Reference to the I14Y publication ID.",
+				"title": "i14y_publication",
+                                "description": "Indicates if the dataset metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
                                 "properties": {
                                     "bv:mustBePublished": {
+					"title": "i14y_publication_flag",
+					"description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication.",
 					"required": true,
                                         "type": "boolean"
                                     },
                                     "dcterms:identifier": {
+					"title": "i14y_id",
 					"required": false,
                                         "type": "string",
-                                        "description": "Identifier for the I14Y publication"
+                                        "description": "Identifier for the dataset on I14Y."
                                     },
                                     "dcat:accessURL": {
+					"title": "i14y_url",
 					"required": false,
                                         "type": "string",
                                         "format": "uri",
-                                        "description": "URL on I14Y"
+                                        "description": "URL for the dataset on I14Y"
                                     }
                                 }
 			    },
                             "dcat:themeTaxonomy": {
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "Reference or URL to a theme taxonomy classification.",
+				"title": "dataset_themes",
+                                "description": "This attribute classifies the dataset into one or more broad thematics. Proper classification allow other users interested in the topic to find the dataset without knowing its name or description.",
                                 "items": {
                                     "type": "string",
                                     "enum": [
@@ -314,24 +332,27 @@
                                 }
                             },
                             "dcat:landingPage": {
+				"title": "Landing_page",
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
                                 "description": "Landing page or homepage for the dataset."
                             },
                             "dcterms:spatial": {
+				"title": "spatial_coverage",
 				"required": false,
                                 "type": "string",
-                                "description": "Spatial/geographical coverage."
+                                "description": "Spatial/geographical coverage of the dataset."
                             },
                             "dcterms:temporal": {
+				"title": "temporal_coverage",
 				"required": false,
                                 "type": "string",
-                                "description": "Temporal coverage of the dataset."
+                                "description": "Temporal coverage of the dataset. For example, the first and last measurement years for a timeseries."
                             },
                             "bv:legalBasis": {
 				"required": false,
-                                "title": "Legal basis",
+                                "title": "Legal_basis",
                                 "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
                                 "type": ["array","null"],
                                 "items": {
@@ -341,6 +362,7 @@
                                 }
                             },
                             "bv:businessProcess": {
+				"title": "business_process",
 				"required": false,
                                 "type": ["array","null"],
                                 "description": "Related business process or context.",
@@ -349,42 +371,50 @@
                                 }
                             },
                             "bv:retentionPeriod": {
+				"title": "retention_period",
 				"required": false,
                                 "type": "integer",
-                                "description": "Retention period for the dataset."
+                                "description": "Retention period for the dataset. That is, the time that the dataset must legally be available after the end of its active use."
                             },
                             "dcat:catalog": {
+				"title": "catalog",
 				"required": false,
                                 "type": "string",
-                                "description": "Indicates which catalog this dataset belongs to."
+                                "description": "Indicates in which catalog this dataset is available."
                             },
                             "prov:wasDerivedFrom": {
+				"title": "derived_from",
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "Source from which this dataset was derived.",
+                                "description": "Links to other datasets from which this dataset was derived.",
                                 "items": {
                                     "type": "string"
                                 }
                             },
                             "bv:geoIdentifier": {
+				"title": "geo_identifier"
 				"required": false,
                                 "type": "string",
-                                "description": "Geographical identifier (e.g., BFS numbers)."
+                                "description": "Identifier for the dataset according to the GeoIV."
                             },
 			    "foaf:page": {
 				"required": false,
     				"type": ["array","null"],
-    				"title": "Related resources",
-    				"description": "Any related page or resource.",
+    				"title": "Related_resources",
+    				"description": "Any related page, document or resource.",
 				"items": {
 					"type": "object",
         				"additionalProperties": false,
         				"properties": {
 					     "alias": {
+						"title": "page_alias",
+						"description": "Alias to be showed in the interface for this link.",
 						"required": false,
 						"type": "string"
 					    },
 					    "uri": {
+						"title": "url",
+						"description": "URL for the page, document or resource",
 						"required": true,
 						"type": ["string", "null"],
                 				"format": "uri"
@@ -393,27 +423,32 @@
 				 }
 			    },
                             "bv:comments": {
+				"title": "comments",
 				"required": false,
                                 "type": "string",
                                 "description": "Additional comments about the dataset."
                             },
                             "bv:abrogation": {
+				"title": "abrogation",
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "date",
-                                "description": "Indicates if the dataset was abrogated or replaced."
+                                "description": "Indicates when the dataset was abrogated or replaced."
                             },
                             "bv:itSystem": {
+				"title": "it_system"
 				"required": false,
                                 "type": "string",
                                 "description": "Name of the IT system managing this dataset."
                             },
                             "dcat:inSeries": {
+				"title": "in_series",
 				"required": false,
                                 "type": "string",
                                 "description": "Reference to the series this dataset belongs to."
                             },
                             "dcterms:replaces": {
+				"title": "replaces",
 				"required": false,
                                 "type": ["array","null"],
                                 "description": "ID of datasets replaced by this one",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -164,7 +164,7 @@
                                 "type": ["string", "null"],
                                 "format": "date",
                                 "title": "Last_modification_date",
-                                "description": "Last modification date of the data in the dataset (not to be confused with the dataset metadata)."
+                                "description": "Last modification date of the data in the dataset."
                             },
                             "bv:affiliatedPersons": {
 				"required": true,
@@ -459,7 +459,8 @@
                             "dcat:distribution": {
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "Distribution info describing how and where to access the dataset.",
+				"title": "Distribution",
+                                "description": "Distribution info describing how and where to access the dataset. This class describes a specific, final, and ready-to-use format in which a dataset is made available to users. For example, the same data may be available as both a CSV file and an Excel file, each representing a separate distribution of the same dataset. Each distribution must be part of a dataset and should point to a reachable source (e.g. an URL for download). All distributions within a dataset must maintain the same level of timeliness across all channels. This means, for instance, that the 2021 CSV file should be published simultaneously with the Excel file, and vice versa.",
                                 "items": {
                                     "type": "object",
                                     "additionalProperties": false,
@@ -469,20 +470,23 @@
                                             "additionalProperties": false,
                                             "properties": {
                                                 "dcterms:identifier": {
+						    "title": "Distribution_id",
 						    "required": true,
                                                     "type": "string",
-                                                    "description": "Identifier for this distribution."
+                                                    "description": "Identifier for this distribution. If left empty, it will be automatically assigned."
                                                 },
                                                 "dcat:accessURL": {
+						    "title": "access_url",
 						    "required": true,
                                                     "type": "string",
                                                     "format": "uri",
-                                                    "description": "URL for accessing this distribution."
+                                                    "description": "URL to a page for accessing this distribution. This must not be a direct download URL but, for example, a link to a webpage containing download links."
                                                 },
                                                 "adms:status": {
+						    "title": "Status",
 						    "required": true,
                                                     "type": "string",
-                                                    "description": "Status of this distribution (e.g., 'active', 'deprecated').",
+                                                    "description": "Current status of the distribution.",
                                                     "enum": [
                                                         "workInProgress",
                                                         "validated",
@@ -492,57 +496,66 @@
                                                     ]
                                                 },
                                                 "dcterms:format": {
+						    "title": "format",
 						    "required": true,
                                                     "type": "string",
-                                                    "description": "File format (e.g., CSV, JSON)."
+                                                    "description": "File format for this distribution (e.g., CSV, JSON)."
                                                 },
                                                 "dcterms:modified": {
+						    "title": "Last_modification_date",
 						    "required": true,
                                                     "type": ["string", "null"],
                                                     "format": "date",
-                                                    "description": "When the distribution file was last modified."
+                                                    "description": "Last modification date of the data in this distribution."
                                                 },
                                                 "dcat:downloadURL": {
+						    "title": "download_url",
 						    "required": false,
                                                     "type": ["string", "null"],
                                                     "format": "uri",
-                                                    "description": "Download URL of the distribution file."
+                                                    "description": "Direct download URL of the distribution file. This link must directly point to the file."
                                                 },
                                                 "dcterms:title": {
+						    "title": "Distribution_title",
 						    "required": false,
                                                     "type": "object",
                                                     "description": "Title for the distribution, in multiple languages.",
                                                     "properties": {
                                                         "de": {
+							    "required": true,
                                                             "type": "string",
                                                             "title": "Deutsch"
                                                         },
                                                         "fr": {
+							    "required": true,
                                                             "type": "string",
                                                             "title": "Français"
                                                         },
                                                         "it": {
+							    "required": false,
                                                             "type": "string",
                                                             "title": "Italiano"
                                                         },
                                                         "en": {
+							    "required": false,
                                                             "type": "string",
                                                             "title": "English"
                                                         }
                                                     }
                                                 },
                                                 "dcterms:description": {
+						    "title": "Distribution_description",
 						    "required": false,
                                                     "type": "object",
                                                     "description": "Description for the distribution, in multiple languages.",
                                                     "properties": {
                                                         "de": {
-							    "required": false,
+							    "required": true,
                                                             "type": "string",
                                                             "title": "Deutsch"
                                                         },
                                                         "fr": {
-							    "required": false,
+							    "required": true,
                                                             "type": "string",
                                                             "title": "Français"
                                                         },
@@ -559,14 +572,16 @@
                                                     }
                                                 },
                                                 "dcterms:conformsTo": {
+						    "title": "conforms_to",
 						    "required": false,
                                                     "type": "string",
                                                     "description": "Reference to a standard or specification the distribution conforms to."
                                                 },
                                                 "dcterms:license": {
+						    "title": "license",
 						    "required": false,
                                                     "type": "string",
-                                                    "description": "License under which this distribution is released.",
+                                                    "description": "License under which this distribution is released. This is mandatory for opendata.swiss publications.",
                                                     "enum": [
                                                         "terms_open",
                                                         "terms_by",
@@ -576,14 +591,16 @@
                                                     ]
                                                 },
                                                 "bv:comments": {
+						    "title": "comments",
 						    "required": false,
                                                     "type": "string",
                                                     "description": "Additional comments about the distribution."
                                                 },
                                                 "dcat:accessService": {
+						    "title": "access_service",
 						    "required": false,
                                                     "type": "string",
-                                                    "description": "Indicates a service used to provide access to the data."
+                                                    "description": "Reference to a service used to provide access to the data."
                                                 }
                                             }
                                         }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -617,7 +617,8 @@
             "description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
             "items": {
                 "type": "object",
-                "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01').",
+		"title": "datasetseries_objects",
+                "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01'). This class represents a collection of datasets that are published and can be used separately, but share some characteristics that group them.",
                 "properties": {
                     "attributes": {
                         "type": "object",
@@ -627,84 +628,100 @@
 				"required": false,
                                 "type": ["string", "null"],
                                 "format": "uri",
-                                "title": "Image URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                                "title": "Image_URL",
+                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the series content."
                             },
 			    "dcterms:identifier": {
+				"title": "Series_id",
 				"required": true,
                                 "type": "string",
-                                "description": "Unique identifier for the dataset series."
+                                "description": "Identifier for this DatasetSeries. If left empty, it will be automatically assigned."
                             },
                             "dcterms:title": {
+				"title": "Series_title",
 				"required": true,
                                 "type": "object",
                                 "description": "Title for the series in multiple languages.",
                                 "properties": {
                                     "de": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Deutsch"
                                     },
                                     "fr": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Français"
                                     },
                                     "it": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Italiano"
                                     },
                                     "en": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "English"
                                     }
                                 }
                             },
                             "dcterms:description": {
+				"title": "Series_description",
 				"required": true,
                                 "type": "object",
                                 "description": "Description for the series in multiple languages.",
                                 "properties": {
                                     "de": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Deutsch"
                                     },
                                     "fr": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Français"
                                     },
                                     "it": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "Italiano"
                                     },
                                     "en": {
 					"required": false,
-                                        "type": "string"
+                                        "type": "string",
+                                        "title": "English"
                                     }
                                 }
                             },
                             "dcat:contactPoint": {
+				"title": "Contact_point",
+                                "description": "Contact information for potential inquiries about the DatasetSeries.",
 				"required": true,
                                 "type": "object",
-                                "description": "Contact information for inquiries.",
                                 "properties": {
                                     "name": {
 					"required": true,
-                                        "type": "string"
+                                        "type": "string",
+					"title": "Name"
                                     },
                                     "email": {
 					"required": true,
                                         "type": "string"
+					"title": "email"
                                     }
                                 }
                             },
                             "dcterms:publisher": {
 				"required": true,
                                 "type": "string",
+				"title": "Publisher",
                                 "description": "Publisher or organization responsible for the series."
                             },
                             "adms:status": {
+				"title": "Status",
 				"required": true,
                                 "type": "string",
-                                "description": "Current status of the dataset (sample enumeration).",
+                                "description": "Current status of the DatasetSeries.",
                                 "enum": [
                                     "workInProgress",
                                     "validated",
@@ -714,9 +731,10 @@
                                 ]
                             },
                             "dcat:dataset": {
+				"title": "series_dataset",
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "Indicates which dataset(s) this series serves or is related to.",
+                                "description": "References which dataset(s) are grouped within this DatasetSeries. Please note that a Dataset may be referenced by multiple DatasetSeries.",
                                 "items": {
                                     "type": "string"
                                 }
@@ -724,17 +742,21 @@
 			    "foaf:page": {
 				"required": false,
     				"type": ["array","null"],
-    				"title": "Related resources",
-    				"description": "Any related page or resource.",
+    				"title": "Related_resources",
+    				"description": "Any related page, document or resource.",
 				"items": {
 					"type": "object",
         				"additionalProperties": false,
         				"properties": {
 					     "alias": {
+						"title": "page_alias",
+						"description": "Alias to be showed in the interface for this link.",
 						"required": false,
 						"type": "string"
 					    },
 					    "uri": {
+						"title": "url",
+						"description": "URL for the page, document or resource",
 						"required": true,
 						"type": ["string", "null"],
                 				"format": "uri"
@@ -743,14 +765,16 @@
 				 }
 			    },
                             "bv:comment": {
+				"title": "comments",
 				"required": false,
                                 "type": "string",
-                                "description": "Additional comments or notes about the series."
+                                "description": "Additional comments or notes about the DatasetSeries."
                             },
                             "dcat:keyword": {
 				"required": false,
                                 "type": ["array","null"],
-                                "description": "Keywords describing the dataset Serie.",
+                                "title": "Keywords",
+                                "description": "Keywords describing the DatasetSeries.",
                                 "items": {
                                     "type": "string"
                                 }
@@ -758,7 +782,8 @@
                             "bv:classification": {
 				"required": true,
                                 "type": "string",
-                                "description": "Classification level of the dataset (sample enumeration).",
+                                "title": "Classification_level",
+                                "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
                                 "enum": [
                                     "none",
                                     "internal",
@@ -769,7 +794,8 @@
                             "bv:personalData": {
 				"required": true,
                                 "type": "string",
-                                "description": "Indicates presence of personal data (e.g., 'Keine', 'Anonymized', etc.).",
+                                "title": "Categorization_DSG",
+                                "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
                                 "enum": [
                                     "none",
                                     "personalData",

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -29,7 +29,7 @@
                     "bv:opendata_swiss",
                     "bv:i14y"
                 ],
-                "title": "Dataset_objects",
+                "title": "Dataset objects",
                 "description": "One item (i.e., one datset metadata) in the collection of datasets. This class describes a collection of homogeneous data characterized by its topic, process, infrastructure (including data processing and storage systems), purpose, and data type. A dataset is also consistent in terms of classification, the presence of personal data, and its degree of openness. Datasets are similar to products; they are prepared and made available to others under clearly defined usage criteria.",
                 "properties": {
                     "schema:image": {
@@ -38,12 +38,12 @@
                             "null"
                         ],
                         "format": "uri",
-                        "title": "Image_URL",
+                        "title": "Image URL",
                         "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the dataset's content."
                     },
                     "dcterms:identifier": {
                         "type": "string",
-                        "title": "Dataset_identifier",
+                        "title": "Dataset identifier",
                         "description": "Unique identifier for the dataset. If left empty, it is automatically assigned."
                     },
                     "dcterms:title": {
@@ -52,7 +52,7 @@
                             "de",
                             "fr"
                         ],
-                        "title": "Dataset_title",
+                        "title": "Dataset title",
                         "description": "Title of the dataset.",
                         "properties": {
                             "de": {
@@ -79,7 +79,7 @@
                             "de",
                             "fr"
                         ],
-                        "title": "Dataset_description",
+                        "title": "Dataset description",
                         "description": "Description of the dataset. Should go into details about the dataset content and help a non-specialist to understand what is the dataset about.",
                         "properties": {
                             "de": {
@@ -102,7 +102,7 @@
                     },
                     "dcterms:accessRights": {
                         "type": "string",
-                        "title": "Access_rights",
+                        "title": "Access rights",
                         "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
                         "enum": [
                             "CONFIDENTIAL",
@@ -123,7 +123,7 @@
                             "schema:name",
                             "schema:email"
                         ],
-                        "title": "Contact_point",
+                        "title": "Contact point",
                         "description": "Contact information for potential inquiries about the dataset.",
                         "properties": {
                             "schema:name": {
@@ -137,7 +137,7 @@
                         }
                     },
                     "dcterms:issued": {
-                        "title": "Issued_date",
+                        "title": "Issued date",
                         "description": "Date when the dataset was formally issued for the first time. If unknown, you may select the date of the first publication of this metadata.",
                         "type": [
                             "string",
@@ -158,7 +158,7 @@
                     },
                     "dcterms:accrualPeriodicity": {
                         "type": "string",
-                        "title": "Accrual_periodicity",
+                        "title": "Accrual periodicity",
                         "description": "Frequency with which dataset is updated (e.g., 'Annual').",
                         "enum": [
                             "OTHER",
@@ -178,12 +178,12 @@
                             "null"
                         ],
                         "format": "date",
-                        "title": "Last_modification_date",
+                        "title": "Last modification date",
                         "description": "Last modification date of the data in the dataset."
                     },
                     "schema:OrganizationRole": {
                         "type": "array",
-                        "title": "Affiliated_persons",
+                        "title": "Affiliated persons",
                         "description": "List of affiliated people, their contact address and respective roles.",
                         "items": {
                             "type": "object",
@@ -237,7 +237,7 @@
                     },
                     "bv:classification": {
                         "type": "string",
-                        "title": "Classification_level",
+                        "title": "Classification level",
                         "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
                         "enum": [
                             "none",
@@ -248,7 +248,7 @@
                     },
                     "bv:personalData": {
                         "type": "string",
-                        "title": "Categorization_DSG",
+                        "title": "Categorization DSG",
                         "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
                         "enum": [
                             "none",
@@ -258,7 +258,7 @@
                     },
                     "bv:typeOfData": {
                         "type": "string",
-                        "title": "Data_type",
+                        "title": "Data type",
                         "description": "Specifies the type of data in the dataset (master data, reference data, thematic data or unstructured data).",
                         "enum": [
                             "thematicData",
@@ -269,7 +269,7 @@
                     },
                     "bv:archivalValue": {
                         "type": "boolean",
-                        "title": "Archival_value",
+                        "title": "Archival value",
                         "description": "Indicates if this dataset has archival value and must be sent to the BAR."
                     },
                     "bv:opendata_swiss": {
@@ -277,21 +277,21 @@
                         "required": [
                             "bv:mustBePublished"
                         ],
-                        "title": "opendataswiss_publication",
+                        "title": "opendataswiss publication",
                         "description": "Indicates if the dataset must be published as Open Government Data (OGD) via the opendata.swiss portal. Optionally references the opendata.swiss publication ID.",
                         "properties": {
                             "bv:mustBePublished": {
-                                "title": "opendataswiss_publication_flag",
+                                "title": "opendataswiss publication flag",
                                 "description": "Indicates if the dataset must be published on opendata.swiss. May be used by harvesters or automatic metadata publication.",
                                 "type": "boolean"
                             },
                             "dcterms:identifier": {
-                                "title": "opendataswiss_id",
+                                "title": "opendataswiss id",
                                 "type": "string",
                                 "description": "Identifier for the dataset on opendata.swiss."
                             },
                             "dcat:accessURL": {
-                                "title": "opendataswiss_url",
+                                "title": "opendataswiss url",
                                 "type": "string",
                                 "format": "uri",
                                 "description": "URL for the dataset on opendata.swiss"
@@ -303,22 +303,22 @@
                         "required": [
                             "bv:mustBePublished"
                         ],
-                        "title": "i14y_publication",
+                        "title": "i14y publication",
                         "description": "Indicates if the dataset metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
                         "properties": {
                             "bv:mustBePublished": {
-                                "title": "i14y_publication_flag",
+                                "title": "i14y publication flag",
                                 "description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
                                 "type": "boolean",
                                 "default": true
                             },
                             "dcterms:identifier": {
-                                "title": "i14y_id",
+                                "title": "i14y id",
                                 "type": "string",
                                 "description": "Identifier for the dataset on I14Y."
                             },
                             "dcat:accessURL": {
-                                "title": "i14y_url",
+                                "title": "i14y url",
                                 "type": "string",
                                 "format": "uri",
                                 "description": "URL for the dataset on I14Y"
@@ -330,7 +330,7 @@
                             "array",
                             "null"
                         ],
-                        "title": "dataset_themes",
+                        "title": "Dataset themes",
                         "description": "This attribute classifies the dataset into one or more broad thematics. Proper classification allow other users interested in the topic to find the dataset without knowing its name or description.",
                         "items": {
                             "type": "string",
@@ -343,7 +343,7 @@
                         }
                     },
                     "dcat:landingPage": {
-                        "title": "Landing_page",
+                        "title": "Landing page",
                         "type": [
                             "string",
                             "null"
@@ -352,17 +352,17 @@
                         "description": "Landing page or homepage for the dataset."
                     },
                     "dcterms:spatial": {
-                        "title": "spatial_coverage",
+                        "title": "Spatial coverage",
                         "type": "string",
                         "description": "Spatial/geographical coverage of the dataset."
                     },
                     "dcterms:temporal": {
-                        "title": "temporal_coverage",
+                        "title": "Temporal coverage",
                         "type": "string",
                         "description": "Temporal coverage of the dataset. For example, the first and last measurement years for a timeseries."
                     },
                     "dpv:hasLegalBasis": {
-                        "title": "Legal_basis",
+                        "title": "Legal basis",
                         "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
                         "type": [
                             "array",
@@ -378,7 +378,7 @@
                         }
                     },
                     "bv:businessProcess": {
-                        "title": "business_process",
+                        "title": "Business process",
                         "type": [
                             "array",
                             "null"
@@ -389,7 +389,7 @@
                         }
                     },
                     "bv:retentionPeriod": {
-                        "title": "retention_period",
+                        "title": "Retention period",
                         "type": "integer",
                         "description": "Retention period for the dataset. That is, the time that the dataset must legally be available after the end of its active use."
                     },
@@ -399,7 +399,7 @@
                         "description": "Indicates in which catalog this dataset is available."
                     },
                     "prov:wasDerivedFrom": {
-                        "title": "derived_from",
+                        "title": "Derived from",
                         "type": [
                             "array",
                             "null"
@@ -410,7 +410,7 @@
                         }
                     },
                     "bv:geoIdentifier": {
-                        "title": "geo_identifier",
+                        "title": "Geo identifier",
                         "type": "string",
                         "description": "Identifier for the dataset according to the GeoIV."
                     },
@@ -419,7 +419,7 @@
                             "array",
                             "null"
                         ],
-                        "title": "Related_resources",
+                        "title": "Related resources",
                         "description": "Any related page, document or resource.",
                         "items": {
                             "type": "object",
@@ -429,7 +429,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "alias": {
-                                    "title": "page_alias",
+                                    "title": "Page alias",
                                     "description": "Alias to be showed in the interface for this link.",
                                     "type": "string"
                                 },
@@ -460,12 +460,12 @@
                         "description": "Indicates when the dataset was abrogated or replaced."
                     },
                     "bv:itSystem": {
-                        "title": "it_system",
+                        "title": "IT system",
                         "type": "string",
                         "description": "Name of the IT system managing this dataset."
                     },
                     "dcat:inSeries": {
-                        "title": "in_series",
+                        "title": "In Series",
                         "type": "string",
                         "description": "Reference to the series this dataset belongs to."
                     },
@@ -499,12 +499,12 @@
                             "additionalProperties": false,
                             "properties": {
                                 "dcterms:identifier": {
-                                    "title": "Distribution_id",
+                                    "title": "Distribution id",
                                     "type": "string",
                                     "description": "Identifier for this distribution. If left empty, it will be automatically assigned."
                                 },
                                 "dcat:accessURL": {
-                                    "title": "access_url",
+                                    "title": "Access URL",
                                     "type": "string",
                                     "format": "uri",
                                     "description": "URL to a page for accessing this distribution. This must not be a direct download URL but, for example, a link to a webpage containing download links."
@@ -527,7 +527,7 @@
                                     "description": "File format for this distribution (e.g., CSV, JSON)."
                                 },
                                 "dcterms:modified": {
-                                    "title": "Last_modification_date",
+                                    "title": "Last modification date",
                                     "type": [
                                         "string",
                                         "null"
@@ -536,7 +536,7 @@
                                     "description": "Last modification date of the data in this distribution."
                                 },
                                 "dcat:downloadURL": {
-                                    "title": "download_url",
+                                    "title": "Download URL",
                                     "type": [
                                         "string",
                                         "null"
@@ -545,7 +545,7 @@
                                     "description": "Direct download URL of the distribution file. This link must directly point to the file."
                                 },
                                 "dcterms:title": {
-                                    "title": "Distribution_title",
+                                    "title": "Distribution title",
                                     "type": "object",
                                     "required": [
                                         "de",
@@ -572,7 +572,7 @@
                                     }
                                 },
                                 "dcterms:description": {
-                                    "title": "Distribution_description",
+                                    "title": "Distribution description",
                                     "type": "object",
                                     "required": [
                                         "de",
@@ -599,7 +599,7 @@
                                     }
                                 },
                                 "dcterms:conformsTo": {
-                                    "title": "conforms_to",
+                                    "title": "Conforms to",
                                     "type": "string",
                                     "description": "Reference to a standard or specification the distribution conforms to."
                                 },
@@ -621,7 +621,7 @@
                                     "description": "Additional comments about the distribution."
                                 },
                                 "dcat:accessService": {
-                                    "title": "access_service",
+                                    "title": "Access service",
                                     "type": "string",
                                     "description": "Reference to a service used to provide access to the data."
                                 }
@@ -646,7 +646,7 @@
                     "bv:classification",
                     "bv:personalData"
                 ],
-                "title": "datasetseries_objects",
+                "title": "DatasetSeries objects",
                 "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01'). This class represents a collection of datasets that are published and can be used separately, but share some characteristics that group them.",
                 "properties": {
                     "schema:image": {
@@ -655,16 +655,16 @@
                             "null"
                         ],
                         "format": "uri",
-                        "title": "Image_URL",
+                        "title": "Image URL",
                         "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the series content."
                     },
                     "dcterms:identifier": {
-                        "title": "Series_id",
+                        "title": "Series id",
                         "type": "string",
                         "description": "Identifier for this DatasetSeries. If left empty, it will be automatically assigned."
                     },
                     "dcterms:title": {
-                        "title": "Series_title",
+                        "title": "Series title",
                         "type": "object",
                         "required": [
                             "de",
@@ -691,7 +691,7 @@
                         }
                     },
                     "dcterms:description": {
-                        "title": "Series_description",
+                        "title": "Series description",
                         "type": "object",
                         "required": [
                             "de",
@@ -718,7 +718,7 @@
                         }
                     },
                     "dcat:contactPoint": {
-                        "title": "Contact_point",
+                        "title": "Contact point",
                         "description": "Contact information for potential inquiries about the DatasetSeries.",
                         "type": "object",
                         "required": [
@@ -754,7 +754,7 @@
                         ]
                     },
                     "dcat:dataset": {
-                        "title": "series_dataset",
+                        "title": "Series dataset",
                         "type": [
                             "array",
                             "null"
@@ -769,7 +769,7 @@
                             "array",
                             "null"
                         ],
-                        "title": "Related_resources",
+                        "title": "Related resources",
                         "description": "Any related page, document or resource.",
                         "items": {
                             "type": "object",
@@ -779,7 +779,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "alias": {
-                                    "title": "page_alias",
+                                    "title": "Page alias",
                                     "description": "Alias to be showed in the interface for this link.",
                                     "type": "string"
                                 },
@@ -813,7 +813,7 @@
                     },
                     "bv:classification": {
                         "type": "string",
-                        "title": "Classification_level",
+                        "title": "Classification level",
                         "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
                         "enum": [
                             "none",
@@ -824,7 +824,7 @@
                     },
                     "bv:personalData": {
                         "type": "string",
-                        "title": "Categorization_DSG",
+                        "title": "Categorization DSG",
                         "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
                         "enum": [
                             "none",
@@ -850,7 +850,7 @@
                     "dcat:endopointURL",
                     "adms:status"
                 ],
-                "title": "dataServices_objects",
+                "title": "DataServices objects",
                 "description": "A DataService represents a collection of operations accessible through an interface (API) that provide access to one or more datasets or data processing functions.",
                 "properties": {
                     "schema:image": {
@@ -859,16 +859,16 @@
                             "null"
                         ],
                         "format": "uri",
-                        "title": "Image_URL",
+                        "title": "Image URL",
                         "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                     },
                     "dcterms:identifier": {
-                        "title": "Service_id",
+                        "title": "Service id",
                         "type": "string",
                         "description": "Identifier for this DataService. If left empty, it will be automatically assigned."
                     },
                     "dcterms:title": {
-                        "title": "dataService_title",
+                        "title": "DataService title",
                         "type": "object",
                         "required": [
                             "de",
@@ -895,7 +895,7 @@
                         }
                     },
                     "dcterms:description": {
-                        "title": "dataService_description",
+                        "title": "DataService description",
                         "type": "object",
                         "required": [
                             "de",
@@ -927,7 +927,7 @@
                         "description": "Publisher or organization responsible for the DataService."
                     },
                     "dcat:contactPoint": {
-                        "title": "Contact_point",
+                        "title": "Contact point",
                         "description": "Contact information for potential inquiries about the DataService.",
                         "type": "object",
                         "required": [
@@ -947,7 +947,7 @@
                     },
                     "dcterms:accessRights": {
                         "type": "string",
-                        "title": "Access_rights",
+                        "title": "Access rights",
                         "description": "Defines the accessibility of the DataService (e.g., public, internal, etc.).",
                         "enum": [
                             "CONFIDENTIAL",
@@ -958,7 +958,7 @@
                         ]
                     },
                     "dcat:endopointURL": {
-                        "title": "endpoint_url",
+                        "title": "Endpoint URL",
                         "type": [
                             "string",
                             "null"
@@ -979,7 +979,7 @@
                         ]
                     },
                     "dcat:servesDataset": {
-                        "title": "serves_dataset",
+                        "title": "Serves dataset",
                         "type": [
                             "array",
                             "null"
@@ -990,7 +990,7 @@
                         }
                     },
                     "dcat:endpointDescription": {
-                        "title": "endpoint_description",
+                        "title": "Endpoint description",
                         "type": [
                             "string",
                             "null"
@@ -1003,7 +1003,7 @@
                             "array",
                             "null"
                         ],
-                        "title": "Related_resources",
+                        "title": "Related resources",
                         "description": "Any related page, document or resource.",
                         "items": {
                             "type": "object",
@@ -1013,7 +1013,7 @@
                             "additionalProperties": false,
                             "properties": {
                                 "alias": {
-                                    "title": "page_alias",
+                                    "title": "Page alias",
                                     "description": "Alias to be showed in the interface for this link.",
                                     "type": "string"
                                 },
@@ -1039,22 +1039,22 @@
                         "required": [
                             "bv:mustBePublished"
                         ],
-                        "title": "i14y_publication",
+                        "title": "I14Y publication",
                         "description": "Indicates if the DataService metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
                         "properties": {
                             "bv:mustBePublished": {
-                                "title": "i14y_publication_flag",
+                                "title": "I14Y publication flag",
                                 "description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
                                 "type": "boolean",
                                 "default": true
                             },
                             "dcterms:identifier": {
-                                "title": "i14y_id",
+                                "title": "I14Y id",
                                 "type": "string",
                                 "description": "Identifier for the DataService on I14Y."
                             },
                             "dcat:accessURL": {
-                                "title": "i14y_url",
+                                "title": "I14Y URL",
                                 "type": "string",
                                 "format": "uri",
                                 "description": "URL for the DataService on I14Y"
@@ -1077,7 +1077,7 @@
                     "dcat:contactPoint",
                     "dcterms:accessRights"
                 ],
-                "title": "catalog_objects",
+                "title": "Catalog objects",
                 "description": "Structure of Catalog. A catalog is a loose collection of Datasets, DatasetSeries and DataServices such as, for example, opendata.swiss or I14Y.",
                 "properties": {
                     "schema:image": {
@@ -1086,16 +1086,16 @@
                             "null"
                         ],
                         "format": "uri",
-                        "title": "Image_URL",
+                        "title": "Image URL",
                         "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
                     },
                     "dcterms:identifier": {
-                        "title": "Catalog_id",
+                        "title": "Catalog id",
                         "type": "string",
                         "description": "Identifier for this Catalog. If left empty, it will be automatically assigned."
                     },
                     "dcterms:title": {
-                        "title": "Catalog_title",
+                        "title": "Catalog title",
                         "type": "object",
                         "required": [
                             "de",
@@ -1122,7 +1122,7 @@
                         }
                     },
                     "dcterms:description": {
-                        "title": "Catalog_description",
+                        "title": "Catalog description",
                         "type": "object",
                         "required": [
                             "de",
@@ -1154,7 +1154,7 @@
                         "description": "Publisher or organization responsible for the Catalog."
                     },
                     "dcat:contactPoint": {
-                        "title": "Contact_point",
+                        "title": "Contact point",
                         "description": "Contact information for potential inquiries about the Catalog.",
                         "type": "object",
                         "required": [
@@ -1173,7 +1173,7 @@
                         }
                     },
                     "dcterms:accessRights": {
-                        "title": "Access_rights",
+                        "title": "Access rights",
                         "type": "string",
                         "description": "Defines the accessibility of the Catalog (e.g., public, internal, etc.).",
                         "enum": [
@@ -1198,7 +1198,7 @@
                             "array",
                             "null"
                         ],
-                        "title": "catalog_datasets",
+                        "title": "Catalog datasets",
                         "description": "IDs of the datasets referenced in the Catalog.",
                         "items": {
                             "type": "string"
@@ -1209,7 +1209,7 @@
                             "array",
                             "null"
                         ],
-                        "title": "catalog_services",
+                        "title": "catalog services",
                         "description": "IDs of the DataServices referenced in the catalog",
                         "items": {
                             "type": "string"

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -11,603 +11,624 @@
             "description": "One or more data catalog blocks can exist in an array. Each block contains `dataset` and `datasetSeries` objects.",
             "items": {
                 "type": "object",
-		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:accessRights", "dcterms:publisher", "dcat:contactPoint", "dcterms:issued", "dcterms:accrualPeriodicity", "dcterms:modified", "schema:OrganizationRole", "adms:status", "bv:classification", "bv:personalData", "bv:archivalValue", "bv:opendata_swiss", "bv:i14y"],
+                "required": [
+                    "dcterms:identifier",
+                    "dcterms:title",
+                    "dcterms:description",
+                    "dcterms:accessRights",
+                    "dcterms:publisher",
+                    "dcat:contactPoint",
+                    "dcterms:issued",
+                    "dcterms:accrualPeriodicity",
+                    "dcterms:modified",
+                    "schema:OrganizationRole",
+                    "adms:status",
+                    "bv:classification",
+                    "bv:personalData",
+                    "bv:archivalValue",
+                    "bv:opendata_swiss",
+                    "bv:i14y"
+                ],
                 "title": "Dataset_objects",
                 "description": "One item (i.e., one datset metadata) in the collection of datasets. This class describes a collection of homogeneous data characterized by its topic, process, infrastructure (including data processing and storage systems), purpose, and data type. A dataset is also consistent in terms of classification, the presence of personal data, and its degree of openness. Datasets are similar to products; they are prepared and made available to others under clearly defined usage criteria.",
                 "properties": {
-                            "schema:image": {
-                                
-				"type": ["string", "null"],
-                                "format": "uri",
-                                "title": "Image_URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the dataset's content."
-                            },
-			    "dcterms:identifier": {
-				
+                    "schema:image": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "title": "Image_URL",
+                        "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the dataset's content."
+                    },
+                    "dcterms:identifier": {
+                        "type": "string",
+                        "title": "Dataset_identifier",
+                        "description": "Unique identifier for the dataset. If left empty, it is automatically assigned."
+                    },
+                    "dcterms:title": {
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "title": "Dataset_title",
+                        "description": "Title of the dataset.",
+                        "properties": {
+                            "de": {
                                 "type": "string",
-                                "title": "Dataset_identifier",
-                                "description": "Unique identifier for the dataset. If left empty, it is automatically assigned."
+                                "title": "Deutsch"
                             },
-                            "dcterms:title": {
-                                
-				"type": "object",
-				"required": ["de", "fr"],
-                                "title": "Dataset_title",
-                                "description": "Title of the dataset.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "title": "Dataset_description",
-                                "description": "Description of the dataset. Should go into details about the dataset content and help a non-specialist to understand what is the dataset about.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:accessRights": {
-				
+                            "fr": {
                                 "type": "string",
-                                "title": "Access_rights",
-                                "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
-                                "enum": [
-                                    "CONFIDENTIAL",
-                                    "NON_PUBLIC",
-                                    "PUBLIC",
-                                    "RESTRICTED",
-                                    "SENSITIVE"
-                                ]
+                                "title": "Français"
                             },
-                            "dcterms:publisher": {
-				
+                            "it": {
                                 "type": "string",
-                                "title": "Publisher",
-                                "description": "Entity (person or organization) who published the dataset."
+                                "title": "Italiano"
                             },
-                            "dcat:contactPoint": {
-				
-                                "type": "object",
-				"required": ["schema:name", "schema:email"],
-                                "title": "Contact_point",
-                                "description": "Contact information for potential inquiries about the dataset.",
-                                "properties": {
-                                    "schema:name": {
-					
-                                        "type": "string",
-					"title": "Name"
-                                    },
-                                    "schema:email": {
-					
-                                        "type": "string",
-					"title": "email"
-                                    }
-                                }
-                            },
-                            "dcterms:issued": {
-				
-                                "title": "Issued_date",
-                                "description": "Date when the dataset was formally issued for the first time. If unknown, you may select the date of the first publication of this metadata.",
-                                "type": ["string", "null"],
-                                "format": "date"
-                            },
-                            "dcat:keyword": {
-				
-                                "type": ["array","null"],
-                                "title": "Keywords",
-                                "description": "Keywords describing the dataset.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcterms:accrualPeriodicity": {
-				
+                            "en": {
                                 "type": "string",
-                                "title": "Accrual_periodicity",
-                                "description": "Frequency with which dataset is updated (e.g., 'Annual').",
-                                "enum": [
-                                    "OTHER",
-                                    "HOURLY",
-                                    "UNKNOWN",
-                                    "QUARTERLY",
-                                    "NEVER",
-				    "MONTHLY",	
-                                    "ANNUAL",
-                                    "DAILY",
-                                    "AS_NEEDED"
-                                ]
-                            },
-                            "dcterms:modified": {
-				
-                                "type": ["string", "null"],
-                                "format": "date",
-                                "title": "Last_modification_date",
-                                "description": "Last modification date of the data in the dataset."
-                            },
-                            "schema:OrganizationRole": {
-				
-                                "type": "array",
-                                "title": "Affiliated_persons",
-                                "description": "List of affiliated people, their contact address and respective roles.",
-                                "items": {
-                                    "type": "object",
-				    "required": ["schema:name", "schema:email", "schema:roleName"],
-                                    "properties": {
-                                        "schema:name": {
-					    
-                                            "type": "string",
-					    "title": "Name"
-                                        },
-                                        "schema:email": {
-					    
-                                            "type": "string",
-					    "title": "email"
-                                        },
-                                        "schema:roleName": {
-					    
-                                            "type": "string",
-					    "title": "Role",
-                                            "description": "Role this person has for this dataset.",
-                                            "enum": [
-                                                "dataOwner",
-                                                "dataSteward",
-                                                "dataCustodian"
-                                            ]
-                                        }
-                                    }
-                                },
-                                "minItems": 1,
-                                "contains": {
-                                    "type": "object",
-                                    "properties": {
-                                        "schema:roleName": {
-					    
-                                            "const": "dataOwner"
-                                        }
-                                    }
-                                }
-                            },
-                            "adms:status": {
-				
+                                "title": "English"
+                            }
+                        }
+                    },
+                    "dcterms:description": {
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "title": "Dataset_description",
+                        "description": "Description of the dataset. Should go into details about the dataset content and help a non-specialist to understand what is the dataset about.",
+                        "properties": {
+                            "de": {
                                 "type": "string",
-                                "title": "Status",
-                                "description": "Current status of the dataset.",
-                                "enum": [
-                                    "workInProgress",
-                                    "validated",
-                                    "published",
-                                    "deleted",
-                                    "archived"
-                                ]
+                                "title": "Deutsch"
                             },
-                            "bv:classification": {
-				
+                            "fr": {
                                 "type": "string",
-                                "title": "Classification_level",
-                                "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
-                                "enum": [
-                                    "none",
-                                    "internal",
-                                    "confidential",
-                                    "secret"
-                                ]
+                                "title": "Français"
                             },
-                            "bv:personalData": {
-				
+                            "it": {
                                 "type": "string",
-                                "title": "Categorization_DSG",
-                                "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
-                                "enum": [
-                                    "none",
-                                    "personalData",
-                                    "sensitivePersonalData"
-                                ]
+                                "title": "Italiano"
                             },
-                            "bv:typeOfData": {
-				
+                            "en": {
                                 "type": "string",
-				"title": "Data_type",
-                                "description": "Specifies the type of data in the dataset (master data, reference data, thematic data or unstructured data).",
-                                "enum": [
-                                    "thematicData",
-                                    "referenceData",
-                                    "masterData",
-                                    "unstructuredData"
-                                ]
+                                "title": "English"
+                            }
+                        }
+                    },
+                    "dcterms:accessRights": {
+                        "type": "string",
+                        "title": "Access_rights",
+                        "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
+                        "enum": [
+                            "CONFIDENTIAL",
+                            "NON_PUBLIC",
+                            "PUBLIC",
+                            "RESTRICTED",
+                            "SENSITIVE"
+                        ]
+                    },
+                    "dcterms:publisher": {
+                        "type": "string",
+                        "title": "Publisher",
+                        "description": "Entity (person or organization) who published the dataset."
+                    },
+                    "dcat:contactPoint": {
+                        "type": "object",
+                        "required": [
+                            "schema:name",
+                            "schema:email"
+                        ],
+                        "title": "Contact_point",
+                        "description": "Contact information for potential inquiries about the dataset.",
+                        "properties": {
+                            "schema:name": {
+                                "type": "string",
+                                "title": "Name"
                             },
-                            "bv:archivalValue": {
-				
-                                "type": "boolean",
-				"title": "Archival_value",
-                                "description": "Indicates if this dataset has archival value and must be sent to the BAR."
-                            },
-                            "bv:opendata_swiss": {
-				
-                                "type": "object",
-				"required": ["bv:mustBePublished"],
-				"title": "opendataswiss_publication",
-                                "description": "Indicates if the dataset must be published as Open Government Data (OGD) via the opendata.swiss portal. Optionally references the opendata.swiss publication ID.",
-                                "properties": {
-                                    "bv:mustBePublished": {
-					"title": "opendataswiss_publication_flag",
-					"description": "Indicates if the dataset must be published on opendata.swiss. May be used by harvesters or automatic metadata publication.",
-					
-                                        "type": "boolean"
-                                    },
-                                    "dcterms:identifier": {
-					"title": "opendataswiss_id",
-					
-                                        "type": "string",
-                                        "description": "Identifier for the dataset on opendata.swiss."
-                                    },
-                                    "dcat:accessURL": {
-					"title": "opendataswiss_url",
-					
-                                        "type": "string",
-                                        "format": "uri",
-                                        "description": "URL for the dataset on opendata.swiss"
-                                    }
-                                }
-                            },
-			    "bv:i14y": {
-				
-				"type": "object",
-				"required": ["bv:mustBePublished"],
-				"title": "i14y_publication",
-                                "description": "Indicates if the dataset metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
-                                "properties": {
-                                    "bv:mustBePublished": {
-					"title": "i14y_publication_flag",
-					"description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
-					
-                                        "type": "boolean",
-					"default": true
-                                    },
-                                    "dcterms:identifier": {
-					"title": "i14y_id",
-					
-                                        "type": "string",
-                                        "description": "Identifier for the dataset on I14Y."
-                                    },
-                                    "dcat:accessURL": {
-					"title": "i14y_url",
-					
-                                        "type": "string",
-                                        "format": "uri",
-                                        "description": "URL for the dataset on I14Y"
-                                    }
-                                }
-			    },
-                            "dcat:themeTaxonomy": {
-				
-                                "type": ["array","null"],
-				"title": "dataset_themes",
-                                "description": "This attribute classifies the dataset into one or more broad thematics. Proper classification allow other users interested in the topic to find the dataset without knowing its name or description.",
-                                "items": {
+                            "schema:email": {
+                                "type": "string",
+                                "title": "email"
+                            }
+                        }
+                    },
+                    "dcterms:issued": {
+                        "title": "Issued_date",
+                        "description": "Date when the dataset was formally issued for the first time. If unknown, you may select the date of the first publication of this metadata.",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date"
+                    },
+                    "dcat:keyword": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "Keywords",
+                        "description": "Keywords describing the dataset.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "dcterms:accrualPeriodicity": {
+                        "type": "string",
+                        "title": "Accrual_periodicity",
+                        "description": "Frequency with which dataset is updated (e.g., 'Annual').",
+                        "enum": [
+                            "OTHER",
+                            "HOURLY",
+                            "UNKNOWN",
+                            "QUARTERLY",
+                            "NEVER",
+                            "MONTHLY",
+                            "ANNUAL",
+                            "DAILY",
+                            "AS_NEEDED"
+                        ]
+                    },
+                    "dcterms:modified": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date",
+                        "title": "Last_modification_date",
+                        "description": "Last modification date of the data in the dataset."
+                    },
+                    "schema:OrganizationRole": {
+                        "type": "array",
+                        "title": "Affiliated_persons",
+                        "description": "List of affiliated people, their contact address and respective roles.",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "schema:name",
+                                "schema:email",
+                                "schema:roleName"
+                            ],
+                            "properties": {
+                                "schema:name": {
                                     "type": "string",
+                                    "title": "Name"
+                                },
+                                "schema:email": {
+                                    "type": "string",
+                                    "title": "email"
+                                },
+                                "schema:roleName": {
+                                    "type": "string",
+                                    "title": "Role",
+                                    "description": "Role this person has for this dataset.",
                                     "enum": [
-                                        "populationAndSociety",
-                                        "agricultureFisheriesForestryFood",
-                                        "internationalTopics",
-                                        "environment"
+                                        "dataOwner",
+                                        "dataSteward",
+                                        "dataCustodian"
                                     ]
                                 }
-                            },
-                            "dcat:landingPage": {
-				"title": "Landing_page",
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "Landing page or homepage for the dataset."
-                            },
-                            "dcterms:spatial": {
-				"title": "spatial_coverage",
-				
-                                "type": "string",
-                                "description": "Spatial/geographical coverage of the dataset."
-                            },
-                            "dcterms:temporal": {
-				"title": "temporal_coverage",
-				
-                                "type": "string",
-                                "description": "Temporal coverage of the dataset. For example, the first and last measurement years for a timeseries."
-                            },
-                            "dpv:hasLegalBasis": {
-				
-                                "title": "Legal_basis",
-                                "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
-                                "type": ["array","null"],
-                                "items": {
-                                    "title": "URI",
-                                    "type": ["string", "null"],
-                                    "format": "uri"
-                                }
-                            },
-                            "bv:businessProcess": {
-				"title": "business_process",
-				
-                                "type": ["array","null"],
-                                "description": "Related business process or context.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "bv:retentionPeriod": {
-				"title": "retention_period",
-				
-                                "type": "integer",
-                                "description": "Retention period for the dataset. That is, the time that the dataset must legally be available after the end of its active use."
-                            },
-                            "dcat:catalog": {
-				"title": "catalog",
-				
-                                "type": "string",
-                                "description": "Indicates in which catalog this dataset is available."
-                            },
-                            "prov:wasDerivedFrom": {
-				"title": "derived_from",
-				
-                                "type": ["array","null"],
-                                "description": "Links to other datasets from which this dataset was derived.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "bv:geoIdentifier": {
-				"title": "geo_identifier",
-				
-                                "type": "string",
-                                "description": "Identifier for the dataset according to the GeoIV."
-                            },
-			    "foaf:page": {
-				
-    				"type": ["array","null"],
-    				"title": "Related_resources",
-    				"description": "Any related page, document or resource.",
-				"items": {
-					"type": "object",
-					"required": ["uri"],
-        				"additionalProperties": false,
-        				"properties": {
-					     "alias": {
-						"title": "page_alias",
-						"description": "Alias to be showed in the interface for this link.",
-						
-						"type": "string"
-					    },
-					    "uri": {
-						"title": "url",
-						"description": "URL for the page, document or resource",
-						
-						"type": ["string", "null"],
-                				"format": "uri"
-					    }
-	    			       }
-				 }
-			    },
-                            "schema:comment": {
-				"title": "comments",
-				
-                                "type": "string",
-                                "description": "Additional comments about the dataset."
-                            },
-                            "bv:abrogation": {
-				"title": "abrogation",
-				
-                                "type": ["string", "null"],
-                                "format": "date",
-                                "description": "Indicates when the dataset was abrogated or replaced."
-                            },
-                            "bv:itSystem": {
-				"title": "it_system",
-				
-                                "type": "string",
-                                "description": "Name of the IT system managing this dataset."
-                            },
-                            "dcat:inSeries": {
-				"title": "in_series",
-				
-                                "type": "string",
-                                "description": "Reference to the series this dataset belongs to."
-                            },
-                            "dcterms:replaces": {
-				"title": "replaces",
-				
-                                "type": ["array","null"],
-                                "description": "ID of datasets replaced by this one",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcat:distribution": {
-				
-                                "type": ["array","null"],
-				"title": "Distribution",
-                                "description": "Distribution info describing how and where to access the dataset. This class describes a specific, final, and ready-to-use format in which a dataset is made available to users. For example, the same data may be available as both a CSV file and an Excel file, each representing a separate distribution of the same dataset. Each distribution must be part of a dataset and should point to a reachable source (e.g. an URL for download). All distributions within a dataset must maintain the same level of timeliness across all channels. This means, for instance, that the 2021 CSV file should be published simultaneously with the Excel file, and vice versa.",
-                                "items": {
-                                    "type": "object",
-				    "required": ["dcterms:identifier", "dcat:accessURL", "adms:status", "dcterms:format", "dcterms:modified"],
-                                    "additionalProperties": false,
-                                    "properties": {
-                                                "dcterms:identifier": {
-						    "title": "Distribution_id",
-						    
-                                                    "type": "string",
-                                                    "description": "Identifier for this distribution. If left empty, it will be automatically assigned."
-                                                },
-                                                "dcat:accessURL": {
-						    "title": "access_url",
-						    
-                                                    "type": "string",
-                                                    "format": "uri",
-                                                    "description": "URL to a page for accessing this distribution. This must not be a direct download URL but, for example, a link to a webpage containing download links."
-                                                },
-                                                "adms:status": {
-						    "title": "Status",
-						    
-                                                    "type": "string",
-                                                    "description": "Current status of the distribution.",
-                                                    "enum": [
-                                                        "workInProgress",
-                                                        "validated",
-                                                        "published",
-                                                        "deleted",
-                                                        "archived"
-                                                    ]
-                                                },
-                                                "dcterms:format": {
-						    "title": "format",
-						    
-                                                    "type": "string",
-                                                    "description": "File format for this distribution (e.g., CSV, JSON)."
-                                                },
-                                                "dcterms:modified": {
-						    "title": "Last_modification_date",
-						    
-                                                    "type": ["string", "null"],
-                                                    "format": "date",
-                                                    "description": "Last modification date of the data in this distribution."
-                                                },
-                                                "dcat:downloadURL": {
-						    "title": "download_url",
-						    
-                                                    "type": ["string", "null"],
-                                                    "format": "uri",
-                                                    "description": "Direct download URL of the distribution file. This link must directly point to the file."
-                                                },
-                                                "dcterms:title": {
-						    "title": "Distribution_title",
-						    
-                                                    "type": "object",
-						    "required": ["de", "fr"],
-                                                    "description": "Title for the distribution, in multiple languages.",
-                                                    "properties": {
-                                                        "de": {
-							    
-                                                            "type": "string",
-                                                            "title": "Deutsch"
-                                                        },
-                                                        "fr": {
-							    
-                                                            "type": "string",
-                                                            "title": "Français"
-                                                        },
-                                                        "it": {
-							    
-                                                            "type": "string",
-                                                            "title": "Italiano"
-                                                        },
-                                                        "en": {
-							    
-                                                            "type": "string",
-                                                            "title": "English"
-                                                        }
-                                                    }
-                                                },
-                                                "dcterms:description": {
-						    "title": "Distribution_description",
-						    
-                                                    "type": "object",
-						    "required": ["de", "fr"],
-                                                    "description": "Description for the distribution, in multiple languages.",
-                                                    "properties": {
-                                                        "de": {
-							    
-                                                            "type": "string",
-                                                            "title": "Deutsch"
-                                                        },
-                                                        "fr": {
-							    
-                                                            "type": "string",
-                                                            "title": "Français"
-                                                        },
-                                                        "it": {
-							    
-                                                            "type": "string",
-                                                            "title": "Italiano"
-                                                        },
-                                                        "en": {
-							    
-                                                            "type": "string",
-                                                            "title": "English"
-                                                        }
-                                                    }
-                                                },
-                                                "dcterms:conformsTo": {
-						    "title": "conforms_to",
-						    
-                                                    "type": "string",
-                                                    "description": "Reference to a standard or specification the distribution conforms to."
-                                                },
-                                                "dcterms:license": {
-						    "title": "license",
-						    
-                                                    "type": "string",
-                                                    "description": "License under which this distribution is released. This is mandatory for opendata.swiss publications.",
-                                                    "enum": [
-                                                        "terms_open",
-                                                        "terms_by",
-                                                        "terms_ask",
-                                                        "terms_by_ask",
-                                                        "cc-zero"
-                                                    ]
-                                                },
-                                                "schema:comment": {
-						    "title": "comments",
-						    
-                                                    "type": "string",
-                                                    "description": "Additional comments about the distribution."
-                                                },
-                                                "dcat:accessService": {
-						    "title": "access_service",
-						    
-                                                    "type": "string",
-                                                    "description": "Reference to a service used to provide access to the data."
-                                                }
-                                    }
+                            }
+                        },
+                        "minItems": 1,
+                        "contains": {
+                            "type": "object",
+                            "properties": {
+                                "schema:roleName": {
+                                    "const": "dataOwner"
                                 }
                             }
                         }
+                    },
+                    "adms:status": {
+                        "type": "string",
+                        "title": "Status",
+                        "description": "Current status of the dataset.",
+                        "enum": [
+                            "workInProgress",
+                            "validated",
+                            "published",
+                            "deleted",
+                            "archived"
+                        ]
+                    },
+                    "bv:classification": {
+                        "type": "string",
+                        "title": "Classification_level",
+                        "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
+                        "enum": [
+                            "none",
+                            "internal",
+                            "confidential",
+                            "secret"
+                        ]
+                    },
+                    "bv:personalData": {
+                        "type": "string",
+                        "title": "Categorization_DSG",
+                        "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
+                        "enum": [
+                            "none",
+                            "personalData",
+                            "sensitivePersonalData"
+                        ]
+                    },
+                    "bv:typeOfData": {
+                        "type": "string",
+                        "title": "Data_type",
+                        "description": "Specifies the type of data in the dataset (master data, reference data, thematic data or unstructured data).",
+                        "enum": [
+                            "thematicData",
+                            "referenceData",
+                            "masterData",
+                            "unstructuredData"
+                        ]
+                    },
+                    "bv:archivalValue": {
+                        "type": "boolean",
+                        "title": "Archival_value",
+                        "description": "Indicates if this dataset has archival value and must be sent to the BAR."
+                    },
+                    "bv:opendata_swiss": {
+                        "type": "object",
+                        "required": [
+                            "bv:mustBePublished"
+                        ],
+                        "title": "opendataswiss_publication",
+                        "description": "Indicates if the dataset must be published as Open Government Data (OGD) via the opendata.swiss portal. Optionally references the opendata.swiss publication ID.",
+                        "properties": {
+                            "bv:mustBePublished": {
+                                "title": "opendataswiss_publication_flag",
+                                "description": "Indicates if the dataset must be published on opendata.swiss. May be used by harvesters or automatic metadata publication.",
+                                "type": "boolean"
+                            },
+                            "dcterms:identifier": {
+                                "title": "opendataswiss_id",
+                                "type": "string",
+                                "description": "Identifier for the dataset on opendata.swiss."
+                            },
+                            "dcat:accessURL": {
+                                "title": "opendataswiss_url",
+                                "type": "string",
+                                "format": "uri",
+                                "description": "URL for the dataset on opendata.swiss"
+                            }
+                        }
+                    },
+                    "bv:i14y": {
+                        "type": "object",
+                        "required": [
+                            "bv:mustBePublished"
+                        ],
+                        "title": "i14y_publication",
+                        "description": "Indicates if the dataset metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
+                        "properties": {
+                            "bv:mustBePublished": {
+                                "title": "i14y_publication_flag",
+                                "description": "Indicates if the dataset must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
+                                "type": "boolean",
+                                "default": true
+                            },
+                            "dcterms:identifier": {
+                                "title": "i14y_id",
+                                "type": "string",
+                                "description": "Identifier for the dataset on I14Y."
+                            },
+                            "dcat:accessURL": {
+                                "title": "i14y_url",
+                                "type": "string",
+                                "format": "uri",
+                                "description": "URL for the dataset on I14Y"
+                            }
+                        }
+                    },
+                    "dcat:themeTaxonomy": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "dataset_themes",
+                        "description": "This attribute classifies the dataset into one or more broad thematics. Proper classification allow other users interested in the topic to find the dataset without knowing its name or description.",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "populationAndSociety",
+                                "agricultureFisheriesForestryFood",
+                                "internationalTopics",
+                                "environment"
+                            ]
+                        }
+                    },
+                    "dcat:landingPage": {
+                        "title": "Landing_page",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "description": "Landing page or homepage for the dataset."
+                    },
+                    "dcterms:spatial": {
+                        "title": "spatial_coverage",
+                        "type": "string",
+                        "description": "Spatial/geographical coverage of the dataset."
+                    },
+                    "dcterms:temporal": {
+                        "title": "temporal_coverage",
+                        "type": "string",
+                        "description": "Temporal coverage of the dataset. For example, the first and last measurement years for a timeseries."
+                    },
+                    "dpv:hasLegalBasis": {
+                        "title": "Legal_basis",
+                        "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "items": {
+                            "title": "URI",
+                            "type": [
+                                "string",
+                                "null"
+                            ],
+                            "format": "uri"
+                        }
+                    },
+                    "bv:businessProcess": {
+                        "title": "business_process",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "description": "Related business process or context.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "bv:retentionPeriod": {
+                        "title": "retention_period",
+                        "type": "integer",
+                        "description": "Retention period for the dataset. That is, the time that the dataset must legally be available after the end of its active use."
+                    },
+                    "dcat:catalog": {
+                        "title": "catalog",
+                        "type": "string",
+                        "description": "Indicates in which catalog this dataset is available."
+                    },
+                    "prov:wasDerivedFrom": {
+                        "title": "derived_from",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "description": "Links to other datasets from which this dataset was derived.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "bv:geoIdentifier": {
+                        "title": "geo_identifier",
+                        "type": "string",
+                        "description": "Identifier for the dataset according to the GeoIV."
+                    },
+                    "foaf:page": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "Related_resources",
+                        "description": "Any related page, document or resource.",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "uri"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "alias": {
+                                    "title": "page_alias",
+                                    "description": "Alias to be showed in the interface for this link.",
+                                    "type": "string"
+                                },
+                                "uri": {
+                                    "title": "url",
+                                    "description": "URL for the page, document or resource",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "format": "uri"
+                                }
+                            }
+                        }
+                    },
+                    "schema:comment": {
+                        "title": "comments",
+                        "type": "string",
+                        "description": "Additional comments about the dataset."
+                    },
+                    "bv:abrogation": {
+                        "title": "abrogation",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date",
+                        "description": "Indicates when the dataset was abrogated or replaced."
+                    },
+                    "bv:itSystem": {
+                        "title": "it_system",
+                        "type": "string",
+                        "description": "Name of the IT system managing this dataset."
+                    },
+                    "dcat:inSeries": {
+                        "title": "in_series",
+                        "type": "string",
+                        "description": "Reference to the series this dataset belongs to."
+                    },
+                    "dcterms:replaces": {
+                        "title": "replaces",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "description": "ID of datasets replaced by this one",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "dcat:distribution": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "Distribution",
+                        "description": "Distribution info describing how and where to access the dataset. This class describes a specific, final, and ready-to-use format in which a dataset is made available to users. For example, the same data may be available as both a CSV file and an Excel file, each representing a separate distribution of the same dataset. Each distribution must be part of a dataset and should point to a reachable source (e.g. an URL for download). All distributions within a dataset must maintain the same level of timeliness across all channels. This means, for instance, that the 2021 CSV file should be published simultaneously with the Excel file, and vice versa.",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "dcterms:identifier",
+                                "dcat:accessURL",
+                                "adms:status",
+                                "dcterms:format",
+                                "dcterms:modified"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "dcterms:identifier": {
+                                    "title": "Distribution_id",
+                                    "type": "string",
+                                    "description": "Identifier for this distribution. If left empty, it will be automatically assigned."
+                                },
+                                "dcat:accessURL": {
+                                    "title": "access_url",
+                                    "type": "string",
+                                    "format": "uri",
+                                    "description": "URL to a page for accessing this distribution. This must not be a direct download URL but, for example, a link to a webpage containing download links."
+                                },
+                                "adms:status": {
+                                    "title": "Status",
+                                    "type": "string",
+                                    "description": "Current status of the distribution.",
+                                    "enum": [
+                                        "workInProgress",
+                                        "validated",
+                                        "published",
+                                        "deleted",
+                                        "archived"
+                                    ]
+                                },
+                                "dcterms:format": {
+                                    "title": "format",
+                                    "type": "string",
+                                    "description": "File format for this distribution (e.g., CSV, JSON)."
+                                },
+                                "dcterms:modified": {
+                                    "title": "Last_modification_date",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "format": "date",
+                                    "description": "Last modification date of the data in this distribution."
+                                },
+                                "dcat:downloadURL": {
+                                    "title": "download_url",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "format": "uri",
+                                    "description": "Direct download URL of the distribution file. This link must directly point to the file."
+                                },
+                                "dcterms:title": {
+                                    "title": "Distribution_title",
+                                    "type": "object",
+                                    "required": [
+                                        "de",
+                                        "fr"
+                                    ],
+                                    "description": "Title for the distribution, in multiple languages.",
+                                    "properties": {
+                                        "de": {
+                                            "type": "string",
+                                            "title": "Deutsch"
+                                        },
+                                        "fr": {
+                                            "type": "string",
+                                            "title": "Français"
+                                        },
+                                        "it": {
+                                            "type": "string",
+                                            "title": "Italiano"
+                                        },
+                                        "en": {
+                                            "type": "string",
+                                            "title": "English"
+                                        }
+                                    }
+                                },
+                                "dcterms:description": {
+                                    "title": "Distribution_description",
+                                    "type": "object",
+                                    "required": [
+                                        "de",
+                                        "fr"
+                                    ],
+                                    "description": "Description for the distribution, in multiple languages.",
+                                    "properties": {
+                                        "de": {
+                                            "type": "string",
+                                            "title": "Deutsch"
+                                        },
+                                        "fr": {
+                                            "type": "string",
+                                            "title": "Français"
+                                        },
+                                        "it": {
+                                            "type": "string",
+                                            "title": "Italiano"
+                                        },
+                                        "en": {
+                                            "type": "string",
+                                            "title": "English"
+                                        }
+                                    }
+                                },
+                                "dcterms:conformsTo": {
+                                    "title": "conforms_to",
+                                    "type": "string",
+                                    "description": "Reference to a standard or specification the distribution conforms to."
+                                },
+                                "dcterms:license": {
+                                    "title": "license",
+                                    "type": "string",
+                                    "description": "License under which this distribution is released. This is mandatory for opendata.swiss publications.",
+                                    "enum": [
+                                        "terms_open",
+                                        "terms_by",
+                                        "terms_ask",
+                                        "terms_by_ask",
+                                        "cc-zero"
+                                    ]
+                                },
+                                "schema:comment": {
+                                    "title": "comments",
+                                    "type": "string",
+                                    "description": "Additional comments about the distribution."
+                                },
+                                "dcat:accessService": {
+                                    "title": "access_service",
+                                    "type": "string",
+                                    "description": "Reference to a service used to provide access to the data."
+                                }
+                            }
+                        }
+                    }
+                }
             }
         },
         "datasetSeries": {
@@ -615,193 +636,203 @@
             "description": "Container for dataset series keyed by an identifier such as 'SERIE-01'.",
             "items": {
                 "type": "object",
-		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcat:contactPoint", "dcterms:publisher", "adms:status", "bv:classification", "bv:personalData"],
-		"title": "datasetseries_objects",
+                "required": [
+                    "dcterms:identifier",
+                    "dcterms:title",
+                    "dcterms:description",
+                    "dcat:contactPoint",
+                    "dcterms:publisher",
+                    "adms:status",
+                    "bv:classification",
+                    "bv:personalData"
+                ],
+                "title": "datasetseries_objects",
                 "description": "Structure of each dataset series entry. Keys are series IDs (e.g. 'SERIE-01'). This class represents a collection of datasets that are published and can be used separately, but share some characteristics that group them.",
                 "properties": {
-                            "schema:image": {
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "title": "Image_URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the series content."
-                            },
-			    "dcterms:identifier": {
-				"title": "Series_id",
-				
+                    "schema:image": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "title": "Image_URL",
+                        "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the series content."
+                    },
+                    "dcterms:identifier": {
+                        "title": "Series_id",
+                        "type": "string",
+                        "description": "Identifier for this DatasetSeries. If left empty, it will be automatically assigned."
+                    },
+                    "dcterms:title": {
+                        "title": "Series_title",
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "description": "Title for the series in multiple languages.",
+                        "properties": {
+                            "de": {
                                 "type": "string",
-                                "description": "Identifier for this DatasetSeries. If left empty, it will be automatically assigned."
+                                "title": "Deutsch"
                             },
-                            "dcterms:title": {
-				"title": "Series_title",
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "description": "Title for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-				"title": "Series_description",
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "description": "Description for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcat:contactPoint": {
-				"title": "Contact_point",
-                                "description": "Contact information for potential inquiries about the DatasetSeries.",
-				
-                                "type": "object",
-				"required": ["schema:name", "schema:email"],
-                                "properties": {
-                                    "schema:name": {
-					
-                                        "type": "string",
-					"title": "Name"
-                                    },
-                                    "schema:email": {
-					
-                                        "type": "string",
-					"title": "email"
-                                    }
-                                }
-                            },
-                            "dcterms:publisher": {
-				
+                            "fr": {
                                 "type": "string",
-				"title": "Publisher",
-                                "description": "Publisher or organization responsible for the series."
+                                "title": "Français"
                             },
-                            "adms:status": {
-				"title": "Status",
-				
+                            "it": {
                                 "type": "string",
-                                "description": "Current status of the DatasetSeries.",
-                                "enum": [
-                                    "workInProgress",
-                                    "validated",
-                                    "published",
-                                    "deleted",
-                                    "archived"
-                                ]
+                                "title": "Italiano"
                             },
-                            "dcat:dataset": {
-				"title": "series_dataset",
-				
-                                "type": ["array","null"],
-                                "description": "References which dataset(s) are grouped within this DatasetSeries. Please note that a Dataset may be referenced by multiple DatasetSeries.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-			    "foaf:page": {
-				
-    				"type": ["array","null"],
-    				"title": "Related_resources",
-    				"description": "Any related page, document or resource.",
-				"items": {
-					"type": "object",
-					"required": ["uri"],
-        				"additionalProperties": false,
-        				"properties": {
-					     "alias": {
-						"title": "page_alias",
-						"description": "Alias to be showed in the interface for this link.",
-						
-						"type": "string"
-					    },
-					    "uri": {
-						"title": "url",
-						"description": "URL for the page, document or resource",
-						
-						"type": ["string", "null"],
-                				"format": "uri"
-					    }
-	    			       }
-				 }
-			    },
-                            "schema:comment": {
-				"title": "comments",
-				
+                            "en": {
                                 "type": "string",
-                                "description": "Additional comments or notes about the DatasetSeries."
-                            },
-                            "dcat:keyword": {
-				
-                                "type": ["array","null"],
-                                "title": "Keywords",
-                                "description": "Keywords describing the DatasetSeries.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "bv:classification": {
-				
-                                "type": "string",
-                                "title": "Classification_level",
-                                "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
-                                "enum": [
-                                    "none",
-                                    "internal",
-                                    "confidential",
-                                    "secret"
-                                ]
-                            },
-                            "bv:personalData": {
-				
-                                "type": "string",
-                                "title": "Categorization_DSG",
-                                "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
-                                "enum": [
-                                    "none",
-                                    "personalData",
-                                    "sensitivePersonalData"
-                                ]
+                                "title": "English"
                             }
                         }
+                    },
+                    "dcterms:description": {
+                        "title": "Series_description",
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "description": "Description for the series in multiple languages.",
+                        "properties": {
+                            "de": {
+                                "type": "string",
+                                "title": "Deutsch"
+                            },
+                            "fr": {
+                                "type": "string",
+                                "title": "Français"
+                            },
+                            "it": {
+                                "type": "string",
+                                "title": "Italiano"
+                            },
+                            "en": {
+                                "type": "string",
+                                "title": "English"
+                            }
+                        }
+                    },
+                    "dcat:contactPoint": {
+                        "title": "Contact_point",
+                        "description": "Contact information for potential inquiries about the DatasetSeries.",
+                        "type": "object",
+                        "required": [
+                            "schema:name",
+                            "schema:email"
+                        ],
+                        "properties": {
+                            "schema:name": {
+                                "type": "string",
+                                "title": "Name"
+                            },
+                            "schema:email": {
+                                "type": "string",
+                                "title": "email"
+                            }
+                        }
+                    },
+                    "dcterms:publisher": {
+                        "type": "string",
+                        "title": "Publisher",
+                        "description": "Publisher or organization responsible for the series."
+                    },
+                    "adms:status": {
+                        "title": "Status",
+                        "type": "string",
+                        "description": "Current status of the DatasetSeries.",
+                        "enum": [
+                            "workInProgress",
+                            "validated",
+                            "published",
+                            "deleted",
+                            "archived"
+                        ]
+                    },
+                    "dcat:dataset": {
+                        "title": "series_dataset",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "description": "References which dataset(s) are grouped within this DatasetSeries. Please note that a Dataset may be referenced by multiple DatasetSeries.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "foaf:page": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "Related_resources",
+                        "description": "Any related page, document or resource.",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "uri"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "alias": {
+                                    "title": "page_alias",
+                                    "description": "Alias to be showed in the interface for this link.",
+                                    "type": "string"
+                                },
+                                "uri": {
+                                    "title": "url",
+                                    "description": "URL for the page, document or resource",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "format": "uri"
+                                }
+                            }
+                        }
+                    },
+                    "schema:comment": {
+                        "title": "comments",
+                        "type": "string",
+                        "description": "Additional comments or notes about the DatasetSeries."
+                    },
+                    "dcat:keyword": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "Keywords",
+                        "description": "Keywords describing the DatasetSeries.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "bv:classification": {
+                        "type": "string",
+                        "title": "Classification_level",
+                        "description": "Classification level of the dataset according to the Swiss Informationssicherheitsgesetz, ISG. For information regarding the categorization, consult <a https://www.fedlex.admin.ch/eli/cc/2022/232/de#art_13'>the Swiss Informationssicherheitsgesetz article 13</a>",
+                        "enum": [
+                            "none",
+                            "internal",
+                            "confidential",
+                            "secret"
+                        ]
+                    },
+                    "bv:personalData": {
+                        "type": "string",
+                        "title": "Categorization_DSG",
+                        "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
+                        "enum": [
+                            "none",
+                            "personalData",
+                            "sensitivePersonalData"
+                        ]
+                    }
+                }
             }
         },
         "dataServices": {
@@ -809,215 +840,226 @@
             "description": "Container for dcat:DataService",
             "items": {
                 "type": "object",
-		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint", "dcterms:accessRights", "dcat:endopointURL", "adms:status"],
-		"title": "dataServices_objects",
+                "required": [
+                    "dcterms:identifier",
+                    "dcterms:title",
+                    "dcterms:description",
+                    "dcterms:publisher",
+                    "dcat:contactPoint",
+                    "dcterms:accessRights",
+                    "dcat:endopointURL",
+                    "adms:status"
+                ],
+                "title": "dataServices_objects",
                 "description": "A DataService represents a collection of operations accessible through an interface (API) that provide access to one or more datasets or data processing functions.",
                 "properties": {
-                            "schema:image": {
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "title": "Image_URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
-                            },
-			    "dcterms:identifier": {
-				"title": "Service_id",
-				
+                    "schema:image": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "title": "Image_URL",
+                        "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                    },
+                    "dcterms:identifier": {
+                        "title": "Service_id",
+                        "type": "string",
+                        "description": "Identifier for this DataService. If left empty, it will be automatically assigned."
+                    },
+                    "dcterms:title": {
+                        "title": "dataService_title",
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "description": "Title for the DataService in multiple languages.",
+                        "properties": {
+                            "de": {
                                 "type": "string",
-                                "description": "Identifier for this DataService. If left empty, it will be automatically assigned."
+                                "title": "Deutsch"
                             },
-                            "dcterms:title": {
-				"title": "dataService_title",
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "description": "Title for the DataService in multiple languages.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-				"title": "dataService_description",
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "description": "Description for the series in multiple languages.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:publisher": {
-				
+                            "fr": {
                                 "type": "string",
-                                "title": "Publisher",
-                                "description": "Publisher or organization responsible for the DataService."
+                                "title": "Français"
                             },
-                            "dcat:contactPoint": {
-				"title": "Contact_point",
-                                "description": "Contact information for potential inquiries about the DataService.",
-				
-                                "type": "object",
-				"required": ["schema:name", "schema:email"],
-                                "properties": {
-                                    "schema:name": {
-					
-                                        "type": "string",
-					"title": "Name"
-                                    },
-                                    "schema:email": {
-					
-                                        "type": "string",
-					"title": "email"
-                                    }
-                                }
-                            },
-                            "dcterms:accessRights": {
-				
+                            "it": {
                                 "type": "string",
-                                "title": "Access_rights",
-                                "description": "Defines the accessibility of the DataService (e.g., public, internal, etc.).",
-                                "enum": [
-                                    "CONFIDENTIAL",
-                                    "NON_PUBLIC",
-                                    "PUBLIC",
-                                    "RESTRICTED",
-                                    "SENSITIVE"
-                                ]
+                                "title": "Italiano"
                             },
-                            "dcat:endopointURL": {
-				"title": "endpoint_url",
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL of the technical endpoint of the DataService."
-                            },
-                            "adms:status": {
-				"title": "Status",
-				
+                            "en": {
                                 "type": "string",
-                                "description": "Current status of the DataService.",
-                                "enum": [
-                                    "workInProgress",
-                                    "validated",
-                                    "published",
-                                    "deleted",
-                                    "archived"
-                                ]
+                                "title": "English"
+                            }
+                        }
+                    },
+                    "dcterms:description": {
+                        "title": "dataService_description",
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "description": "Description for the series in multiple languages.",
+                        "properties": {
+                            "de": {
+                                "type": "string",
+                                "title": "Deutsch"
                             },
-                            "dcat:servesDataset": {
-				"title": "serves_dataset",
-				
-                                "type": ["array","null"],
-                                "description": "IDs of the datasets served by this DataService",
-                                "items": {
+                            "fr": {
+                                "type": "string",
+                                "title": "Français"
+                            },
+                            "it": {
+                                "type": "string",
+                                "title": "Italiano"
+                            },
+                            "en": {
+                                "type": "string",
+                                "title": "English"
+                            }
+                        }
+                    },
+                    "dcterms:publisher": {
+                        "type": "string",
+                        "title": "Publisher",
+                        "description": "Publisher or organization responsible for the DataService."
+                    },
+                    "dcat:contactPoint": {
+                        "title": "Contact_point",
+                        "description": "Contact information for potential inquiries about the DataService.",
+                        "type": "object",
+                        "required": [
+                            "schema:name",
+                            "schema:email"
+                        ],
+                        "properties": {
+                            "schema:name": {
+                                "type": "string",
+                                "title": "Name"
+                            },
+                            "schema:email": {
+                                "type": "string",
+                                "title": "email"
+                            }
+                        }
+                    },
+                    "dcterms:accessRights": {
+                        "type": "string",
+                        "title": "Access_rights",
+                        "description": "Defines the accessibility of the DataService (e.g., public, internal, etc.).",
+                        "enum": [
+                            "CONFIDENTIAL",
+                            "NON_PUBLIC",
+                            "PUBLIC",
+                            "RESTRICTED",
+                            "SENSITIVE"
+                        ]
+                    },
+                    "dcat:endopointURL": {
+                        "title": "endpoint_url",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "description": "URL of the technical endpoint of the DataService."
+                    },
+                    "adms:status": {
+                        "title": "Status",
+                        "type": "string",
+                        "description": "Current status of the DataService.",
+                        "enum": [
+                            "workInProgress",
+                            "validated",
+                            "published",
+                            "deleted",
+                            "archived"
+                        ]
+                    },
+                    "dcat:servesDataset": {
+                        "title": "serves_dataset",
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "description": "IDs of the datasets served by this DataService",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "dcat:endpointDescription": {
+                        "title": "endpoint_description",
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "description": "URL of technical documentation of the DataService, such as for example a Swagger documentation."
+                    },
+                    "foaf:page": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "Related_resources",
+                        "description": "Any related page, document or resource.",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "uri"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "alias": {
+                                    "title": "page_alias",
+                                    "description": "Alias to be showed in the interface for this link.",
                                     "type": "string"
+                                },
+                                "uri": {
+                                    "title": "url",
+                                    "description": "URL for the page, document or resource",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "format": "uri"
                                 }
+                            }
+                        }
+                    },
+                    "schema:comment": {
+                        "title": "comments",
+                        "type": "string",
+                        "description": "Additional comments about the DataService."
+                    },
+                    "bv:i14y": {
+                        "type": "object",
+                        "required": [
+                            "bv:mustBePublished"
+                        ],
+                        "title": "i14y_publication",
+                        "description": "Indicates if the DataService metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
+                        "properties": {
+                            "bv:mustBePublished": {
+                                "title": "i14y_publication_flag",
+                                "description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
+                                "type": "boolean",
+                                "default": true
                             },
-                            "dcat:endpointDescription": {
-				"title": "endpoint_description",
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "description": "URL of technical documentation of the DataService, such as for example a Swagger documentation."
-                            },
-			    "foaf:page": {
-				
-    				"type": ["array","null"],
-    				"title": "Related_resources",
-    				"description": "Any related page, document or resource.",
-				"items": {
-					"type": "object",
-					"required": ["uri"],
-        				"additionalProperties": false,
-        				"properties": {
-					     "alias": {
-						"title": "page_alias",
-						"description": "Alias to be showed in the interface for this link.",
-						
-						"type": "string"
-					    },
-					    "uri": {
-						"title": "url",
-						"description": "URL for the page, document or resource",
-						
-						"type": ["string", "null"],
-                				"format": "uri"
-					    }
-	    			       }
-				 }
-			    },
-                            "schema:comment": {
-				"title": "comments",
-				
+                            "dcterms:identifier": {
+                                "title": "i14y_id",
                                 "type": "string",
-                                "description": "Additional comments about the DataService."
+                                "description": "Identifier for the DataService on I14Y."
                             },
-			    "bv:i14y": {
-				
-				"type": "object",
-				"required": ["bv:mustBePublished"],
-				"title": "i14y_publication",
-                                "description": "Indicates if the DataService metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
-                                "properties": {
-                                    "bv:mustBePublished": {
-					"title": "i14y_publication_flag",
-					"description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication. This is true by default.",
-					
-                                        "type": "boolean",
-					"default": true
-                                    },
-                                    "dcterms:identifier": {
-					"title": "i14y_id",
-					
-                                        "type": "string",
-                                        "description": "Identifier for the DataService on I14Y."
-                                    },
-                                    "dcat:accessURL": {
-					"title": "i14y_url",
-					
-                                        "type": "string",
-                                        "format": "uri",
-                                        "description": "URL for the DataService on I14Y"
-                                    }
-                                }
+                            "dcat:accessURL": {
+                                "title": "i14y_url",
+                                "type": "string",
+                                "format": "uri",
+                                "description": "URL for the DataService on I14Y"
+                            }
+                        }
                     }
                 }
             }
@@ -1027,144 +1069,152 @@
             "description": "container for dcat:Catalog",
             "items": {
                 "type": "object",
-		"required": ["dcterms:identifier", "dcterms:title", "dcterms:description", "dcterms:publisher", "dcat:contactPoint", "dcterms:accessRights"],
-		"title": "catalog_objects",
+                "required": [
+                    "dcterms:identifier",
+                    "dcterms:title",
+                    "dcterms:description",
+                    "dcterms:publisher",
+                    "dcat:contactPoint",
+                    "dcterms:accessRights"
+                ],
+                "title": "catalog_objects",
                 "description": "Structure of Catalog. A catalog is a loose collection of Datasets, DatasetSeries and DataServices such as, for example, opendata.swiss or I14Y.",
                 "properties": {
-                            "schema:image": {
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-                                "title": "Image_URL",
-                                "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
-                            },
-			    "dcterms:identifier": {
-				"title": "Catalog_id",
-				
+                    "schema:image": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "title": "Image_URL",
+                        "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
+                    },
+                    "dcterms:identifier": {
+                        "title": "Catalog_id",
+                        "type": "string",
+                        "description": "Identifier for this Catalog. If left empty, it will be automatically assigned."
+                    },
+                    "dcterms:title": {
+                        "title": "Catalog_title",
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "description": "Title for the Catalog in multiple languages.",
+                        "properties": {
+                            "de": {
                                 "type": "string",
-                                "description": "Identifier for this Catalog. If left empty, it will be automatically assigned."
+                                "title": "Deutsch"
                             },
-                            "dcterms:title": {
-				"title": "Catalog_title",
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "description": "Title for the Catalog in multiple languages.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:description": {
-				"title": "Catalog_description",
-				
-                                "type": "object",
-				"required": ["de", "fr"],
-                                "description": "Description for the Catalog in multiple languages.",
-                                "properties": {
-                                    "de": {
-					
-                                        "type": "string",
-                                        "title": "Deutsch"
-                                    },
-                                    "fr": {
-					
-                                        "type": "string",
-                                        "title": "Français"
-                                    },
-                                    "it": {
-					
-                                        "type": "string",
-                                        "title": "Italiano"
-                                    },
-                                    "en": {
-					
-                                        "type": "string",
-                                        "title": "English"
-                                    }
-                                }
-                            },
-                            "dcterms:publisher": {
-				
-				"title": "Publisher",
+                            "fr": {
                                 "type": "string",
-                                "description": "Publisher or organization responsible for the Catalog."
+                                "title": "Français"
                             },
-                            "dcat:contactPoint": {
-				"title": "Contact_point",
-                                "description": "Contact information for potential inquiries about the Catalog.",
-				
-                                "type": "object",
-				"required": ["schema:name", "schema:email"],
-                                "properties": {
-                                    "schema:name": {
-					
-                                        "type": "string",
-					"title": "Name"
-                                    },
-                                    "schema:email": {
-					
-                                        "type": "string",
-					"title": "email"
-                                    }
-                                }
-                            },
-                            "dcterms:accessRights": {
-				"title": "Access_rights",
-				
+                            "it": {
                                 "type": "string",
-                                "description": "Defines the accessibility of the Catalog (e.g., public, internal, etc.).",
-                                "enum": [
-                                    "CONFIDENTIAL",
-                                    "NON_PUBLIC",
-                                    "PUBLIC",
-                                    "RESTRICTED",
-                                    "SENSITIVE"
-                                ]
+                                "title": "Italiano"
                             },
-                            "foaf:homepage": {
-				
-                                "type": ["string", "null"],
-                                "format": "uri",
-				"title": "homepage",
-                                "description": "Homepage for the Catalog."
-                            },
-                            "dcat:dataset": {
-				
-                                "type": ["array","null"],
-				"title": "catalog_datasets",
-                                "description": "IDs of the datasets referenced in the Catalog.",
-                                "items": {
-                                    "type": "string"
-                                }
-                            },
-                            "dcat:service": {
-				
-                                "type": ["array","null"],
-				"title": "catalog_services",
-                                "description": "IDs of the DataServices referenced in the catalog",
-                                "items": {
-                                    "type": "string"
-                                }
+                            "en": {
+                                "type": "string",
+                                "title": "English"
                             }
+                        }
+                    },
+                    "dcterms:description": {
+                        "title": "Catalog_description",
+                        "type": "object",
+                        "required": [
+                            "de",
+                            "fr"
+                        ],
+                        "description": "Description for the Catalog in multiple languages.",
+                        "properties": {
+                            "de": {
+                                "type": "string",
+                                "title": "Deutsch"
+                            },
+                            "fr": {
+                                "type": "string",
+                                "title": "Français"
+                            },
+                            "it": {
+                                "type": "string",
+                                "title": "Italiano"
+                            },
+                            "en": {
+                                "type": "string",
+                                "title": "English"
+                            }
+                        }
+                    },
+                    "dcterms:publisher": {
+                        "title": "Publisher",
+                        "type": "string",
+                        "description": "Publisher or organization responsible for the Catalog."
+                    },
+                    "dcat:contactPoint": {
+                        "title": "Contact_point",
+                        "description": "Contact information for potential inquiries about the Catalog.",
+                        "type": "object",
+                        "required": [
+                            "schema:name",
+                            "schema:email"
+                        ],
+                        "properties": {
+                            "schema:name": {
+                                "type": "string",
+                                "title": "Name"
+                            },
+                            "schema:email": {
+                                "type": "string",
+                                "title": "email"
+                            }
+                        }
+                    },
+                    "dcterms:accessRights": {
+                        "title": "Access_rights",
+                        "type": "string",
+                        "description": "Defines the accessibility of the Catalog (e.g., public, internal, etc.).",
+                        "enum": [
+                            "CONFIDENTIAL",
+                            "NON_PUBLIC",
+                            "PUBLIC",
+                            "RESTRICTED",
+                            "SENSITIVE"
+                        ]
+                    },
+                    "foaf:homepage": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "uri",
+                        "title": "homepage",
+                        "description": "Homepage for the Catalog."
+                    },
+                    "dcat:dataset": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "catalog_datasets",
+                        "description": "IDs of the datasets referenced in the Catalog.",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "dcat:service": {
+                        "type": [
+                            "array",
+                            "null"
+                        ],
+                        "title": "catalog_services",
+                        "description": "IDs of the DataServices referenced in the catalog",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         }

--- a/data/dataCatalogSchema.json
+++ b/data/dataCatalogSchema.json
@@ -991,7 +991,34 @@
 				"required": false,
                                 "type": "string",
                                 "description": "Additional comments about the DataService."
-                            }
+                            },
+			    "bv:i14y": {
+				"required": true,
+				"type": "object",
+				"title": "i14y_publication",
+                                "description": "Indicates if the DataService metadata must be made available via the interoperability platform I14Y. Optionally references the I14Y publication ID.",
+                                "properties": {
+                                    "bv:mustBePublished": {
+					"title": "i14y_publication_flag",
+					"description": "Indicates if the DataService must be published on I14Y. May be used by harvesters or automatic metadata publication.",
+					"required": true,
+                                        "type": "boolean"
+                                    },
+                                    "dcterms:identifier": {
+					"title": "i14y_id",
+					"required": false,
+                                        "type": "string",
+                                        "description": "Identifier for the DataService on I14Y."
+                                    },
+                                    "dcat:accessURL": {
+					"title": "i14y_url",
+					"required": false,
+                                        "type": "string",
+                                        "format": "uri",
+                                        "description": "URL for the DataService on I14Y"
+                                    }
+                                }
+			    }
                         }
                     }
                 }


### PR DESCRIPTION
This PR includes:

- Removal of the metadata blocks from the schema objects, as preparation for #19
- Moving the "required" information: fixes #20 
- Updates and fixes the attribute names and description: fixes #12 
- Updates some attributes to use established ontologies and vocabularies such as schema.org: fixes #13 

Additionally, it expands the foaf:page property in order to allow an URI and an alias for it (alias is optional)