### PR TITLE
Allow longer titles (two lines) in both tile and table view

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -33,9 +33,25 @@ h1 {
   margin-bottom: 0.5em;
 }
 
-h5.tile-title-ellipsis {
+h6.tile-title-ellipsis {
   font-weight: bold;
+  font-size: 1em;
   margin-bottom: 4px;
+  display: -webkit-box;          /* for multi-line flex-based ellipsis */
+  -webkit-box-orient: vertical;  /* vertical orientation */
+  -webkit-line-clamp: 2;         /* number of lines to allow */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;           /* must allow normal wrapping rather than nowrap */
+}
+
+.table-title-two-line {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;         /* number of lines to show */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: normal;           /* must allow normal wrapping */
 }
 
 p {
@@ -44,6 +60,7 @@ p {
 
 p.tile-desc-ellipsis {
   margin-bottom: 4px;
+  line-height: 1.25;
 }
 
 a {

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -188,7 +188,7 @@ function tileCardTemplate(dataset) {
       <div class="card h-100 dataset-card" data-id="${dataset["dct:identifier"]}">
         <img src="${imageSrc}" class="card-img-top" alt="${title}" />
         <div class="card-body">
-          <h5 class="tile-title-ellipsis">${title}</h5>
+          <h6 class="tile-title-ellipsis">${title}</h6>
           <p class="tile-desc-ellipsis">${desc}</p>
           ${dateHTML}
           <div class="keywords">${keywordsHTML}</div>
@@ -209,7 +209,9 @@ function tableRowTemplate(dataset) {
     .join(" ");
   return `
     <tr class="dataset-row" data-id="${identifier}">
-      <td>${title}</td>
+      <td>
+        <div class="table-title-two-line">${title}</div>
+      </td>
       <td>${issued}</td>
       <td>
         <a href="https://admindir.verzeichnisse.admin.ch/person/${owner}" 

--- a/docs/assets/js/utils.js
+++ b/docs/assets/js/utils.js
@@ -38,13 +38,8 @@ const Utils = {
     const formattedEnd = this.formatDate(endDate, lang, options);
     return `${formattedStart} - ${formattedEnd}`;
   },  
-  truncate(str, length = 50) {
-    if (!str) return "";
-    return str.length > length ? str.slice(0, length) + "..." : str;
-  },
   getDisplayTitle(dataset, lang) {
-    const rawTitle = (dataset["dct:title"] && dataset["dct:title"][lang]) || "Untitled";
-    return Utils.truncate(rawTitle, 50);
+    return (dataset["dct:title"] && dataset["dct:title"][lang]) || "N/A";
   },
 
   // Functions shared with details.js


### PR DESCRIPTION
- More compact tile description
- Reduced font size for titles
- Allow two lines of titles for both tile and table view

![image](https://github.com/user-attachments/assets/55fbca78-e28b-420c-be0b-20ebbb6ab0d0)

![image](https://github.com/user-attachments/assets/45033ec7-615a-4fba-b559-eb6b2382af5a)
