### PR TITLE
Hotfix: Move from unpgk to jsDelivr for the i18next script

### DIFF
--- a/docs/about.html
+++ b/docs/about.html
@@ -47,7 +47,7 @@
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/twbs-pagination/1.4.2/jquery.twbsPagination.min.js"
     ></script>
-    <script src="https://unpkg.com/i18next@latest/dist/umd/i18next.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/i18next@latest/dist/umd/i18next.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
 

--- a/docs/details.html
+++ b/docs/details.html
@@ -43,7 +43,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/twbs-pagination/1.4.2/jquery.twbsPagination.min.js"></script>
-    <script src="https://unpkg.com/i18next@latest/dist/umd/i18next.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/i18next@latest/dist/umd/i18next.js"></script>
     <script src="assets/js/utils.js"></script>
     <script src="assets/js/details.js"></script>
     <script src="assets/js/i18n.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -85,7 +85,7 @@
       <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/twbs-pagination/1.4.2/jquery.twbsPagination.min.js"></script>
-      <script src="https://unpkg.com/i18next@latest/dist/umd/i18next.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/i18next@latest/dist/umd/i18next.js"></script>
       <script src="assets/js/utils.js"></script>
       <script src="assets/js/main.js"></script>
       <script src="assets/js/i18n.js"></script>


### PR DESCRIPTION
## 📄 Affected Page

- All pages using `i18next.js`

## 🔍 Issue

- The original script source from **unpkg** was returning a `503 Service Unavailable` error: `GET https://unpkg.com/i18next@latest/dist/umd/i18next.js net::ERR_ABORTED 503 (Service Unavailable)`

## ✅ Solution

- Replaced the **unpkg** CDN with the more reliable **jsDelivr** alternative.
