### PR TITLE
Feature/28: Full CRUD options

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -413,3 +413,8 @@ footer a:hover {
   display: block;
   margin: 0 auto;
 }
+
+/* Mofify page */
+span.help-block {
+  font-size: 0.8rem;
+}

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -418,3 +418,8 @@ footer a:hover {
 span.help-block {
   font-size: 0.8rem;
 }
+legend {
+  font-family: 'Inter', sans-serif;
+  font-weight: 900;
+  font-size: 1.6rem;
+}

--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -1,197 +1,346 @@
 {
     "form": [
-        {
-            "title": "Aesthetics",
-            "type": "fieldset",
-            "items": ["schema:image"]
-        },
-        {
+      {
+        "type": "fieldset",
+        "title": "Basic Information",
+        "items": [
+          "schema:image",
+          {
+            "type": "help",
+            "helpvalue": "Give your dataset a clear, descriptive title in at least DE and FR."
+          },
+          {
             "type": "fieldset",
             "title": "Title",
-            "expandable": false,
             "items": [
-                "dct:title.de",
-                "dct:title.fr",
-                "dct:title.it",
-                "dct:title.en"
+              "dct:title.de",
+              "dct:title.fr",
+              "dct:title.it",
+              "dct:title.en"
             ]
-        },
-        {
+          },
+          {
+            "type": "help",
+            "helpvalue": "Provide a concise but sufficiently detailed description in multiple languages."
+          },
+          {
             "type": "fieldset",
             "title": "Description",
-            "expandable": false,
             "items": [
-                {
-                    "key": "dct:description.de",
-                    "type": "textarea"
-                },
-                {
-                    "key": "dct:description.fr",
-                    "type": "textarea"
-                },
-                {
-                    "key": "dct:description.it",
-                    "type": "textarea"
-                },
-                {
-                    "key": "dct:description.en",
-                    "type": "textarea"
-                }
+              {
+                "key": "dct:description.de",
+                "type": "textarea"
+              },
+              {
+                "key": "dct:description.fr",
+                "type": "textarea"
+              },
+              {
+                "key": "dct:description.it",
+                "type": "textarea"
+              },
+              {
+                "key": "dct:description.en",
+                "type": "textarea"
+              }
             ]
-        },
-        {
+          },
+          {
+            "key": "dcat:keyword",
+            "type": "array",
+            "items": {
+              "key": "dcat:keyword[]",
+              "type": "text",
+              "placeholder": "Enter a keyword"
+            }
+          },
+          {
+            "key": "dcat:theme",
+            "type": "array"
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Access & Classification",
+        "items": [
+          {
+            "key": "adms:status",
+            "title": "Dataset Status"
+          },
+          {
+            "key": "dct:accessRights",
+            "title": "Access Rights"
+          },
+          {
+            "key": "dcatap:availability",
+            "title": "Availability"
+          },
+          {
+            "key": "bv:classification",
+            "title": "Classification Level"
+          },
+          {
+            "key": "bv:personalData",
+            "title": "Data Protection Category"
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Archival & Publication",
+        "items": [
+          {
+            "key": "bv:archivalValue",
+            "inlinetitle": "Is this dataset archival?"
+          },
+          {
+            "key": "bv:retentionPeriod",
+            "title": "Retention Period"
+          },
+          {
             "type": "fieldset",
-            "title": "Affiliated roles",
+            "title": "opendata.swiss",
             "items": [
-                {
-                    "type": "tabarray",
-                    "items": [
-                      {
-                        "type": "section",
-                        "legend": "{{idx}}. {{value}}",
-                        "items": [
-                            {
-                                "key": "prov:qualifiedAttribution[].prov:agent"
-                            },
-                            {
-                                "key": "prov:qualifiedAttribution[].schema:name"
-                            },
-                            {
-                                "key": "prov:qualifiedAttribution[].schema:email"
-                            },
-                            {
-                                "key": "prov:qualifiedAttribution[].dcat:hadRole",
-                                "valueInLegend": true
-                            }
-                        ]
-                      }
-                    ]
-                }
+              "bv:opendata_swiss.bv:mustBePublished",
+              "bv:opendata_swiss.dct:identifier",
+              "bv:opendata_swiss.dcat:accessURL"
             ]
-        },
-        {
+          },
+          {
             "type": "fieldset",
-            "title": "Contact",
+            "title": "i14y",
             "items": [
-                {
-                    "key": "dct:publisher"
-                },
-                {
-                    "key": "dcat:contactPoint.schema:name"
-                },
-                {
-                    "key": "dcat:contactPoint.schema:email"
-                }
+              "bv:i14y.bv:mustBePublished",
+              "bv:i14y.dct:identifier",
+              "bv:i14y.dcat:accessURL"
             ]
-        },
-        {
-            "type": "fieldset",
-            "title": "Dataset status",
-            "expandable": false,
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Publisher & Contact",
+        "items": [
+          "dct:publisher",
+          "dcat:contactPoint.schema:name",
+          "dcat:contactPoint.schema:email"
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Affiliated Roles (Qualified Attribution)",
+        "items": [
+          {
+            "type": "tabarray",
             "items": [
-                {
-                    "key": "adms:status"
-                },
-                {
-                    "key": "dct:accessRights"
-                },
-                {
-                    "key": "dcatap:availability"
-                },
-                {
-                    "key": "bv:archivalValue",
-                    "inlinetitle": "Check this box if the dataset should be archived"
-                },
-                {
-                    "key": "bv:retentionPeriod"
-                },
-                {
-                    "key": "dcatap:availability"
-                }
+              {
+                "type": "section",
+                "legend": "{{idx}}. {{value}}",
+                "items": [
+                  "prov:qualifiedAttribution[].prov:agent",
+                  "prov:qualifiedAttribution[].schema:name",
+                  "prov:qualifiedAttribution[].schema:email",
+                  {
+                    "key": "prov:qualifiedAttribution[].dcat:hadRole",
+                    "valueInLegend": true
+                  }
+                ]
+              }
             ]
-        },
-        {
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Timelines",
+        "items": [
+          {
+            "key": "dct:issued",
+            "type": "date",
+            "title": "Issued Date"
+          },
+          {
+            "key": "dct:modified",
+            "type": "date",
+            "title": "Last Modified Date"
+          },
+          {
+            "key": "dct:accrualPeriodicity",
+            "title": "Accrual Periodicity"
+          },
+          {
             "type": "fieldset",
-            "title": "Dates and Periods",
-            "expandable": false,
+            "title": "Temporal Coverage",
             "items": [
-                {
-                    "key": "dct:issued",
+              {
+                "key": "dct:temporal.dcat:start_date",
+                "type": "date"
+              },
+              {
+                "key": "dct:temporal.dcat:end_date",
+                "type": "date"
+              }
+            ]
+          },
+          {
+            "key": "bv:abrogation",
+            "type": "date",
+            "title": "Abrogation Date"
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Spatial & References",
+        "items": [
+          "dct:spatial",
+          "dcat:landingPage",
+          "bv:geoIdentifier",
+          {
+            "type": "help",
+            "helpvalue": "Add links to relevant pages, documents or related resources."
+          },
+          {
+            "key": "foaf:page",
+            "type": "array",
+            "items": {
+              "type": "fieldset",
+              "items": [
+                "foaf:page[].alias",
+                "foaf:page[].uri"
+              ]
+            }
+          },
+          "dcat:inSeries",
+          "dcat:catalog",
+          {
+            "key": "dct:replaces",
+            "type": "array"
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "items": [
+          {
+            "key": "dcatap:applicableLegislation",
+            "type": "array"
+          },
+          {
+            "key": "prov:wasGeneratedBy",
+            "type": "array"
+          },
+          {
+            "key": "prov:wasDerivedFrom",
+            "type": "array"
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "IT System & Additional Info",
+        "items": [
+          "bv:itSystem",
+          {
+            "key": "dcat:version"
+          },
+          {
+            "key": "schema:comment",
+            "type": "textarea"
+          }
+        ]
+      },
+      {
+        "type": "fieldset",
+        "title": "Distributions",
+        "items": [
+          {
+            "type": "tabarray",
+            "items": [
+              {
+                "type": "section",
+                "legend": "{{idx}}. {{value}}",
+                "items": [
+                  {
+                    "key": "dcat:distribution[].dct:title.de",
+                    "type": "text",
+                    "title": "Distribution Title (DE)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:title.fr",
+                    "type": "text",
+                    "title": "Distribution Title (FR)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:title.it",
+                    "type": "text",
+                    "title": "Distribution Title (IT)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:title.en",
+                    "type": "text",
+                    "title": "Distribution Title (EN)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:description.de",
+                    "type": "textarea",
+                    "title": "Distribution Description (DE)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:description.fr",
+                    "type": "textarea",
+                    "title": "Distribution Description (FR)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:description.it",
+                    "type": "textarea",
+                    "title": "Distribution Description (IT)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:description.en",
+                    "type": "textarea",
+                    "title": "Distribution Description (EN)"
+                  },
+                  {
+                    "key": "dcat:distribution[].dcat:accessURL"
+                  },
+                  {
+                    "key": "dcat:distribution[].adms:status"
+                  },
+                  {
+                    "key": "dcat:distribution[].dcatap:availability"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:format",
+                    "valueInLegend": true
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:modified",
                     "type": "date"
-                },
-                {
-                    "key": "dct:modified",
-                    "type": "date"
-                },
-                {
-                    "key": "dct:accrualPeriodicity"
-                }
+                  },
+                  {
+                    "key": "dcat:distribution[].dcat:downloadURL"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:conformsTo"
+                  },
+                  {
+                    "key": "dcat:distribution[].dct:license"
+                  },
+                  {
+                    "key": "dcat:distribution[].schema:comment",
+                    "type": "textarea"
+                  },
+                  {
+                    "key": "dcat:distribution[].dcat:accessService"
+                  }
+                ]
+              }
             ]
-        },
-        {
-            "type": "fieldset",
-            "title": "Distributions",
-            "expandable": false,
-            "items": [
-                {
-                    "type": "tabarray",
-                    "items": [
-                      {
-                        "type": "section",
-                        "legend": "{{idx}}. {{value}}",
-                        "items": [
-                            {
-                                "key": "dcat:distribution[].dct:title.de",
-                                "type": "text",
-                                "title": "Title (German)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:title.fr",
-                                "type": "text",
-                                "title": "Title (French)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:title.it",
-                                "type": "text",
-                                "title": "Title (Italian)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:title.en",
-                                "type": "text",
-                                "title": "Title (English)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:description.de",
-                                "type": "textarea",
-                                "title": "Description (German)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:description.fr",
-                                "type": "textarea",
-                                "title": "Description (French)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:description.it",
-                                "type": "textarea",
-                                "title": "Description (Italian)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:description.en",
-                                "type": "textarea",
-                                "title": "Description (English)"
-                            },
-                            {
-                                "key": "dcat:distribution[].dcat:accessURL"
-                            },
-                            {
-                                "key": "dcat:distribution[].dct:format",
-                                "valueInLegend": true
-                            }
-                        ]
-                      }
-                    ]
-                }
-            ]
-        }
+          }
+        ]
+      }
     ]
-}
+  }
+  

--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -1,589 +1,55 @@
 {
-    "schema": {
-        "items": {
-            "type": "object",
-            "title": "Dataset metadata",
-            "description": "One item (i.e., one datset metadata) in the collection of datasets.",
-            "required": ["metadata", "attributes"],
-            "properties": {
-                "metadata": {
-                    "type": "object",
-                    "title": "Metadata about the dataset metadata (maybe meta-metadata?)",
-                    "description": "Metadata about the dataset, including last change date, user, etc.",
-                    "required": [
-                        "lastChangeDate",
-                        "lastChangeUser"
-                    ],
-                    "properties": {
-                        "lastChangeDate": {
-                            "type": "string",
-                            "format": "date-time",
-                            "title": "Last change date and time",
-                            "description": "Date and time when the dataset metadata was modified the last time."
-                        },
-                        "lastChangeUser": {
-                            "type": "string",
-                            "title": "Last change user",
-                            "description": "User that changed the dataset metadata for the last time."
-                        },
-                        "imageURL": {
-                            "type": ["string", "null"],
-                            "format": "uri",
-                            "title": "Image URL",
-                            "description": "URL for an image to be displayed in the data catalog. Choose an image that is related to the datasets content."
-                        }
-                    }
-                },
-                "attributes": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "title": "Dataset metadata",
-                    "description": "Descriptive attributes for the dataset itself, i.e. the actual dataset metadata.",
-                    "required": [
-                        "dcterms:identifier",
-                        "dcterms:title",
-                        "dcterms:description",
-                        "dcterms:accessRights",
-                        "bv:affiliatedPersons"
-                    ],
-                    "properties": {
-                        "dcterms:identifier": {
-                            "type": "string",
-                            "title": "Dataset identifier",
-                            "description": "Unique identifier for the dataset."
-                        },
-                        "dcterms:title": {
-                            "type": "object",
-                            "title": "Title",
-                            "description": "Title of the dataset.",
-                            "properties": {
-                                "de": {
-                                    "type": "string",
-                                    "title": "Deutsch",
-                                    "required": true
-                                },
-                                "fr": {
-                                    "type": "string",
-                                    "title": "Français",
-                                    "required": true
-                                },
-                                "it": {
-                                    "type": "string",
-                                    "title": "Italiano"
-                                },
-                                "en": {
-                                    "type": "string",
-                                    "title": "English"
-                                }
-                            },
-                            "required": ["de", "fr"]
-                        },
-                        "dcterms:description": {
-                            "type": "object",
-                            "title": "Description",
-                            "description": "Description of the dataset. May go into details about the dataset content.",
-                            "properties": {
-                                "de": {
-                                    "type": "string",
-                                    "title": "Deutsch",
-                                    "required": true
-                                },
-                                "fr": {
-                                    "type": "string",
-                                    "title": "Français",
-                                    "required": true
-                                },
-                                "it": {
-                                    "type": "string",
-                                    "title": "Italiano"
-                                },
-                                "en": {
-                                    "type": "string",
-                                    "title": "English"
-                                }
-                            },
-                            "required": ["de", "fr"]
-                        },
-                        "dcterms:accessRights": {
-                            "type": "string",
-                            "title": "Access rights",
-                            "description": "Defines the accessibility of the dataset (e.g., public, internal, etc.).",
-                            "enum": [
-                                "CONFIDENTIAL",
-                                "NON_PUBLIC",
-                                "PUBLIC",
-                                "RESTRICTED",
-                                "SENSITIVE"
-                            ]
-                        },
-                        "dcterms:publisher": {
-                            "type": "string",
-                            "title": "Publisher",
-                            "description": "Name of the entity (person or organization) who published the dataset."
-                        },
-                        "dcat:contactPoint": {
-                            "type": "object",
-                            "title": "Contact point",
-                            "description": "Contact information for potential inquiries abou the dataset.",
-                            "properties": {
-                                "name": {
-                                    "type": "string"
-                                },
-                                "email": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": ["name", "email"]
-                        },
-                        "dcterms:issued": {
-                            "title": "Issued date",
-                            "description": "Date when the dataset was formally issued.",
-                            "type": ["string", "null"],
-                            "format": "date"
-                        },
-                        "dcat:keyword": {
-                            "type": ["array","null"],
-                            "title": "Keywords",
-                            "description": "Keywords describing the dataset.",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "dcterms:accrualPeriodicity": {
-                            "type": "string",
-                            "title": "Accrual periodicity",
-                            "description": "Frequency with which dataset is updated (e.g., 'Annual').",
-                            "enum": [
-                                "OTHER",
-                                "HOURLY",
-                                "UNKNOWN",
-                                "QUARTERLY",
-                                "NEVER",
-                                "MONTHLY",	
-                                "ANNUAL",
-                                "DAILY",
-                                "AS_NEEDED"
-                            ]
-                        },
-                        "dcterms:modified": {
-                            "type": ["string", "null"],
-                            "format": "date",
-                            "title": "Last modification date",
-                            "description": "Last modification date of the dataset (not to be confused with the dataset metadata)."
-                        },
-                        "bv:affiliatedPersons": {
-                            "type": "array",
-                            "title": "Affiliated person(s)",
-                            "description": "List of affiliated people, their contact address and respective roles.",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "name": {
-                                        "type": "string"
-                                    },
-                                    "email": {
-                                        "type": "string"
-                                    },
-                                    "role": {
-                                        "type": "string",
-                                        "description": "role",
-                                        "enum": [
-                                            "dataOwner",
-                                            "dataSteward",
-                                            "dataCustodian"
-                                        ]
-                                    }
-                                },
-                                "required": ["name", "email", "role"]
-                            },
-                            "minItems": 1,
-                            "contains": {
-                                "type": "object",
-                                "properties": {
-                                    "role": {
-                                        "const": "dataOwner"
-                                    }
-                                },
-                                "required": ["role"]
-                            }
-                        },
-                        "adms:status": {
-                            "type": "string",
-                            "title": "Status",
-                            "description": "Current status of the dataset (sample enumeration).",
-                            "enum": [
-                                "workInProgress",
-                                "validated",
-                                "published",
-                                "deleted",
-                                "archived"
-                            ]
-                        },
-                        "bv:classification": {
-                            "type": "string",
-                            "title": "Classification level",
-                            "description": "Classification level of the dataset (sample enumeration).",
-                            "enum": [
-                                "none",
-                                "internal",
-                                "confidential",
-                                "secret"
-                            ]
-                        },
-                        "bv:personalData": {
-                            "type": "string",
-                            "title": "Categorization regarding data protection act",
-                            "description": "Categorization regarding the Swiss data protection act. For information regarding the categorization, consult <a href='https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5'>the Swiss data protection act article 5</a>.",
-                            "enum": [
-                                "none",
-                                "personalData",
-                                "sensitivePersonalData"
-                            ]
-                        },
-                        "bv:typeOfData": {
-                            "type": "string",
-                            "description": "Specifies the type of data (structured, unstructured, etc.).",
-                            "enum": [
-                                "thematicData",
-                                "referenceData",
-                                "masterData",
-                                "unstructuredData"
-                            ]
-                        },
-                        "bv:archivalValue": {
-                            "type": "boolean",
-                            "description": "Indicates if this dataset has archival value."
-                        },
-                        "bv:opendata.swiss": {
-                            "type": "object",
-                            "description": "Reference to the Open Government Data publication ID.",
-                            "properties": {
-                                "bv:mustBePublished": {
-                                    "type": "boolean"
-                                },
-                                "dcterms:identifier": {
-                                    "type": "string",
-                                    "description": "Identifier for the OGD publication"
-                                },
-                                "dcat:accessURL": {
-                                    "type": "string",
-                                    "format": "uri",
-                                    "description": "URL on opendata.swiss"
-                                }
-                            }
-                        },
-                        "bv:i14y": {
-                            "type": "object",
-                            "description": "Reference to the I14Y publication ID.",
-                            "properties": {
-                                "bv:mustBePublished": {
-                                    "type": "boolean"
-                                },
-                                "dcterms:identifier": {
-                                    "type": "string",
-                                    "description": "Identifier for the I14Y publication"
-                                },
-                                "dcat:accessURL": {
-                                    "type": "string",
-                                    "format": "uri",
-                                    "description": "URL on I14Y"
-                                }
-                            }
-                        },
-                        "dcat:themeTaxonomy": {
-                            "type": ["array","null"],
-                            "description": "Reference or URL to a theme taxonomy classification.",
-                            "items": {
-                                "type": "string",
-                                "enum": [
-                                    "populationAndSociety",
-                                    "agricultureFisheriesForestryFood",
-                                    "internationalTopics",
-                                    "environment"
-                                ]
-                            }
-                        },
-                        "dcat:landingPage": {
-                            "type": ["string", "null"],
-                            "format": "uri",
-                            "description": "Landing page or homepage for the dataset."
-                        },
-                        "dcterms:spatial": {
-                            "type": "string",
-                            "description": "Spatial/geographical coverage."
-                        },
-                        "dcterms:temporal": {
-                            "type": "string",
-                            "description": "Temporal coverage of the dataset."
-                        },
-                        "bv:legalBasis": {
-                            "title": "Legal basis",
-                            "description": "Legal basis for the dataset (as URI, e.g. 'https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5').",
-                            "type": ["array","null"],
-                            "items": {
-                                "title": "IRI",
-                                "type": ["string", "null"],
-                                "format": "uri"
-                            }
-                        },
-                        "bv:businessProcess": {
-                            "type": ["array","null"],
-                            "title": "Business processes",
-                            "description": "Related business process or context.",
-                            "items": {
-                                "type": "string",
-                                "title": "Process"
-                            }
-                        },
-                        "bv:retentionPeriod": {
-                            "type": "integer",
-                            "title": "Retention period",
-                            "description": "Retention period for the dataset."
-                        },
-                        "dcat:catalog": {
-                            "type": "string",
-                            "description": "Indicates which catalog this dataset belongs to."
-                        },
-                        "prov:wasDerivedFrom": {
-                            "type": ["array","null"],
-                            "title": "Data derivation source",
-                            "description": "Source from which this dataset was derived.",
-                            "items": {
-                                "type": "string",
-                                "title": "Source"
-                            }
-                        },
-                        "bv:geoIdentifier": {
-                            "type": "string",
-                            "description": "Geographical identifier (e.g., BFS numbers)."
-                        },
-                        "foaf:page": {
-                            "type": ["array","null"],
-                            "description": "Any related page or resource.",
-                            "items": {
-                                "type": ["string", "null"],
-                                "format": "uri"
-                            }
-                        },
-                        "bv:comments": {
-                            "type": "string",
-                            "description": "Additional comments about the dataset."
-                        },
-                        "bv:abrogation": {
-                            "type": ["string", "null"],
-                            "format": "date",
-                            "description": "Indicates if the dataset was abrogated or replaced."
-                        },
-                        "bv:itSystem": {
-                            "type": "string",
-                            "description": "Name of the IT system managing this dataset."
-                        },
-                        "dcat:inSeries": {
-                            "type": "string",
-                            "description": "Reference to the series this dataset belongs to."
-                        },
-                        "dcterms:replaces": {
-                            "type": ["array","null"],
-                            "description": "ID of datasets replaced by this one",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "dcat:distribution": {
-                            "type": ["array","null"],
-                            "description": "Distribution info describing how and where to access the dataset.",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "required": ["metadata", "attributes"],
-                                "properties": {
-                                    "metadata": {
-                                        "type": "object",
-                                        "description": "Metadata about the distribution, including last change date, user, etc.",
-                                        "required": [
-                                            "lastChangeDate",
-                                            "lastChangeUser"
-                                        ],
-                                        "properties": {
-                                            "lastChangeDate": {
-                                                "type": "string",
-                                                "format": "date-time",
-                                                "description": "Date/time when the dataset was last updated."
-                                            },
-                                            "lastChangeUser": {
-                                                "type": "string",
-                                                "description": "Name or identifier of the user who performed the last update."
-                                            },
-                                            "imageURL": {
-                                                "type": ["string", "null"],
-                                                "format": "uri"
-                                            }
-                                        }
-                                    },
-                                    "attributes": {
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "required": [
-                                            "dcterms:identifier",
-                                            "dcat:accessURL",
-                                            "dcterms:title",
-                                            "dcterms:description"
-                                        ],
-                                        "properties": {
-                                            "dcterms:identifier": {
-                                                "type": "string",
-                                                "description": "Identifier for this distribution."
-                                            },
-                                            "dcat:accessURL": {
-                                                "type": "string",
-                                                "format": "uri",
-                                                "title": "Access URL",
-                                                "description": "URL for accessing this distribution."
-                                            },
-                                            "adms:status": {
-                                                "type": "string",
-                                                "description": "Status of this distribution (e.g., 'active', 'deprecated').",
-                                                "enum": [
-                                                    "workInProgress",
-                                                    "validated",
-                                                    "published",
-                                                    "deleted",
-                                                    "archived"
-                                                ]
-                                            },
-                                            "dcterms:format": {
-                                                "type": "string",
-                                                "title": "Format",
-                                                "description": "File format (e.g., CSV, JSON).",
-                                                "enum": [
-                                                    "XSLX",
-                                                    "CSV",
-                                                    "JSON",
-                                                    "API",
-                                                    "SPARQL Endpoint",
-                                                    "XML",
-                                                    "Other"
-                                                ]
-                                            },
-                                            "dcterms:modified": {
-                                                "type": ["string", "null"],
-                                                "format": "date",
-                                                "description": "When the distribution file was last modified."
-                                            },
-                                            "dcat:downloadURL": {
-                                                "type": ["string", "null"],
-                                                "format": "uri",
-                                                "description": "Download URL of the distribution file."
-                                            },
-                                            "dcterms:title": {
-                                                "type": "object",
-                                                "description": "Title for the distribution, in multiple languages.",
-                                                "properties": {
-                                                    "de": {
-                                                        "type": "string",
-                                                        "title": "Deutsch"
-                                                    },
-                                                    "fr": {
-                                                        "type": "string",
-                                                        "title": "Français"
-                                                    },
-                                                    "it": {
-                                                        "type": "string",
-                                                        "title": "Italiano"
-                                                    },
-                                                    "en": {
-                                                        "type": "string",
-                                                        "title": "English"
-                                                    }
-                                                }
-                                            },
-                                            "dcterms:description": {
-                                                "type": "object",
-                                                "description": "Description for the distribution, in multiple languages.",
-                                                "properties": {
-                                                    "de": {
-                                                        "type": "string",
-                                                        "title": "Deutsch"
-                                                    },
-                                                    "fr": {
-                                                        "type": "string",
-                                                        "title": "Français"
-                                                    },
-                                                    "it": {
-                                                        "type": "string",
-                                                        "title": "Italiano"
-                                                    },
-                                                    "en": {
-                                                        "type": "string",
-                                                        "title": "English"
-                                                    }
-                                                }
-                                            },
-                                            "dcterms:conformsTo": {
-                                                "type": "string",
-                                                "description": "Reference to a standard or specification the distribution conforms to."
-                                            },
-                                            "dcterms:license": {
-                                                "type": "string",
-                                                "description": "License under which this distribution is released.",
-                                                "enum": [
-                                                    "terms_open",
-                                                    "terms_by",
-                                                    "terms_ask",
-                                                    "terms_by_ask",
-                                                    "cc-zero"
-                                                ]
-                                            },
-                                            "bv:comments": {
-                                                "type": "string",
-                                                "description": "Additional comments about the distribution."
-                                            },
-                                            "dcat:accessService": {
-                                                "type": "string",
-                                                "description": "Indicates a service used to provide access to the data."
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
     "form": [
         {
             "type": "fieldset",
-            "title": "Dataset title",
+            "items": ["schema:image"]
+        },
+        {
+            "type": "fieldset",
+            "title": "Title",
             "expandable": false,
             "items": [
-                "items.attributes.dcterms:title.de",
-                "items.attributes.dcterms:title.fr",
-                "items.attributes.dcterms:title.it",
-                "items.attributes.dcterms:title.en"
+                "dct:title.de",
+                "dct:title.fr",
+                "dct:title.it",
+                "dct:title.en"
             ]
         },
         {
             "type": "fieldset",
-            "title": "Dataset description",
+            "title": "Description",
             "expandable": false,
             "items": [
                 {
-                    "key": "items.attributes.dcterms:description.de",
+                    "key": "dct:description.de",
                     "type": "textarea"
                 },
                 {
-                    "key": "items.attributes.dcterms:description.fr",
+                    "key": "dct:description.fr",
                     "type": "textarea"
                 },
                 {
-                    "key": "items.attributes.dcterms:description.it",
+                    "key": "dct:description.it",
                     "type": "textarea"
                 },
                 {
-                    "key": "items.attributes.dcterms:description.en",
+                    "key": "dct:description.en",
                     "type": "textarea"
+                }
+            ]
+        },
+        {
+            "type": "fieldset",
+            "title": "Contact",
+            "items": [
+                {
+                    "key": "dct:publisher"
+                },
+                {
+                    "key": "dcat:contactPoint.schema:name"
+                },
+                {
+                    "key": "dcat:contactPoint.schema:email"
                 }
             ]
         },
@@ -593,16 +59,7 @@
             "expandable": false,
             "items": [
                 {
-                    "key": "items.attributes.dcterms:accessRights"
-                },
-                {
-                    "key": "items.attributes.bv:personalData"
-                },
-                {
-                    "key": "items.attributes.adms:status"
-                },
-                {
-                    "key": "items.attributes.bv:legalBasis"
+                    "key": "dct:accessRights"
                 }
             ]
         },
@@ -612,85 +69,17 @@
             "expandable": false,
             "items": [
                 {
-                    "key": "items.attributes.dcterms:issued",
+                    "key": "dct:issued",
                     "type": "date"
                 },
                 {
-                    "key": "items.attributes.dcterms:modified",
+                    "key": "dct:modified",
                     "type": "date"
                 },
                 {
-                    "key": "items.attributes.dcterms:accrualPeriodicity"
-                }
-            ]
-        },
-        {
-            "type": "fieldset",
-            "title": "Business details",
-            "expandable": false,
-            "items": [
-                {
-                    "key": "items.attributes.bv:retentionPeriod",
-                    "type": "number"
-                },
-                {
-                    "key": "items.attributes.bv:businessProcess"
-                },
-                {
-                    "key": "items.attributes.prov:wasDerivedFrom"
-                }
-            ]
-        },
-        {
-            "type": "fieldset",
-            "title": "Distributions",
-            "expandable": false,
-            "items": [
-                {
-                    "type": "tabarray",
-                    "items": [
-                      {
-                        "type": "section",
-                        "legend": "{{idx}}. {{value}}",
-                        "items": [
-                            {
-                                "key": "items.attributes.dcat:distribution[].attributes.dcterms:title.de",
-                                "type": "text",
-                                "title": "Title (German)"
-                            },
-                            {
-                                "key": "items.attributes.dcat:distribution[].attributes.dcterms:title.fr",
-                                "type": "text",
-                                "title": "Title (French)"
-                            },
-                            {
-                                "key": "items.attributes.dcat:distribution[].attributes.dcterms:title.it",
-                                "type": "text",
-                                "title": "Title (Italian)"
-                            },
-                            {
-                                "key": "items.attributes.dcat:distribution[].attributes.dcterms:title.en",
-                                "type": "text",
-                                "title": "Title (English)"
-                            },
-                            {
-                                "key": "items.attributes.dcat:distribution[].attributes.dcat:accessURL"
-                            },
-                            {
-                                "key": "items.attributes.dcat:distribution[].attributes.dcterms:format",
-                                "valueInLegend": true
-                            }
-                        ]
-                      }
-                    ]
+                    "key": "dct:accrualPeriodicity"
                 }
             ]
         }
-    ],
-    "value": {
-        "items.attributes.dcterms:title.de": "Hallo, Sie können dies ändern.",
-        "items.attributes.dcterms:title.fr": "Bonjour, vous pouvez changer cela.",
-        "items.attributes.dcterms:title.it": "Ciao, puoi cambiare questo.",
-        "items.attributes.dcterms:title.en": "Hello, you can change this."
-    }
+    ]
 }

--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -1,6 +1,10 @@
 {
     "form": [
       {
+        "key": "dct:identifier",
+        "type": "hidden"
+      },
+      {
         "type": "fieldset",
         "title": "Basic Information",
         "items": [
@@ -287,6 +291,10 @@
                 "type": "section",
                 "legend": "{{idx}}. {{value}}",
                 "items": [
+                  {
+                    "key": "dcat:distribution[].dct:identifier",
+                    "type": "hidden"
+                  },
                   {
                     "key": "dcat:distribution[].dct:title.de",
                     "type": "text",

--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -10,8 +10,7 @@
         "items": [
           "schema:image",
           {
-            "type": "help",
-            "helpvalue": "Give your dataset a clear, descriptive title in at least DE and FR."
+            "type": "help"
           },
           {
             "type": "fieldset",
@@ -24,8 +23,7 @@
             ]
           },
           {
-            "type": "help",
-            "helpvalue": "Provide a concise but sufficiently detailed description in multiple languages."
+            "type": "help"
           },
           {
             "type": "fieldset",
@@ -113,7 +111,10 @@
             "type": "fieldset",
             "title": "opendata.swiss",
             "items": [
-              "bv:opendata_swiss.bv:mustBePublished",
+              {
+                "key": "bv:opendata_swiss.bv:mustBePublished",
+                "inlinetitle": "Should this dataset be published to opendata.swiss?"
+              },
               "bv:opendata_swiss.dct:identifier",
               "bv:opendata_swiss.dcat:accessURL"
             ]
@@ -122,7 +123,10 @@
             "type": "fieldset",
             "title": "i14y",
             "items": [
-              "bv:i14y.bv:mustBePublished",
+              {
+                "key": "bv:i14y.bv:mustBePublished",
+                "inlinetitle": "Should this dataset be published to i14y?"
+              },
               "bv:i14y.dct:identifier",
               "bv:i14y.dcat:accessURL"
             ]
@@ -168,21 +172,17 @@
         "items": [
           {
             "key": "dct:issued",
-            "type": "date",
-            "title": "Issued Date"
+            "type": "date"
           },
           {
             "key": "dct:modified",
-            "type": "date",
-            "title": "Last Modified Date"
+            "type": "date"
           },
           {
-            "key": "dct:accrualPeriodicity",
-            "title": "Accrual Periodicity"
+            "key": "dct:accrualPeriodicity"
           },
           {
             "type": "fieldset",
-            "title": "Temporal Coverage",
             "items": [
               {
                 "key": "dct:temporal.dcat:start_date",
@@ -196,8 +196,7 @@
           },
           {
             "key": "bv:abrogation",
-            "type": "date",
-            "title": "Abrogation Date"
+            "type": "date"
           }
         ]
       },
@@ -209,12 +208,11 @@
           "dcat:landingPage",
           "bv:geoIdentifier",
           {
-            "type": "help",
-            "helpvalue": "Add links to relevant pages, documents or related resources."
+            "type": "help"
           },
           {
             "key": "foaf:page",
-            "type": "array",
+            "type": "tabarray",
             "items": {
               "type": "fieldset",
               "items": [
@@ -227,7 +225,13 @@
           "dcat:catalog",
           {
             "key": "dct:replaces",
-            "type": "array"
+            "type": "array",
+            "items": {
+              "key": "dct:replaces[]",
+              "type": "text",
+              "notitle": true,
+              "placeholder": "Enter the dataset ID of the dataset that is replaced by this dataset."
+            }
           }
         ]
       },
@@ -251,7 +255,7 @@
               "key": "prov:wasGeneratedBy[]",
               "type": "text",
               "notitle": true,
-              "placeholder": "<TO BE COMPLETED>"
+              "placeholder": "Add a link or a name of a business process that is relevant to this dataset."
             }
           },
           {
@@ -261,7 +265,7 @@
               "key": "prov:wasDerivedFrom[]",
               "type": "text",
               "notitle": true,
-              "placeholder": "<TO BE COMPLETED>"
+              "placeholder": "Add a link or an ID to a dataset from which this dataset was derived."
             }
           }
         ]

--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -1,6 +1,7 @@
 {
     "form": [
         {
+            "title": "Aesthetics",
             "type": "fieldset",
             "items": ["schema:image"]
         },
@@ -40,6 +41,36 @@
         },
         {
             "type": "fieldset",
+            "title": "Affiliated roles",
+            "items": [
+                {
+                    "type": "tabarray",
+                    "items": [
+                      {
+                        "type": "section",
+                        "legend": "{{idx}}. {{value}}",
+                        "items": [
+                            {
+                                "key": "prov:qualifiedAttribution[].prov:agent"
+                            },
+                            {
+                                "key": "prov:qualifiedAttribution[].schema:name"
+                            },
+                            {
+                                "key": "prov:qualifiedAttribution[].schema:email"
+                            },
+                            {
+                                "key": "prov:qualifiedAttribution[].dcat:hadRole",
+                                "valueInLegend": true
+                            }
+                        ]
+                      }
+                    ]
+                }
+            ]
+        },
+        {
+            "type": "fieldset",
             "title": "Contact",
             "items": [
                 {
@@ -55,11 +86,27 @@
         },
         {
             "type": "fieldset",
-            "title": "Security and access",
+            "title": "Dataset status",
             "expandable": false,
             "items": [
                 {
+                    "key": "adms:status"
+                },
+                {
                     "key": "dct:accessRights"
+                },
+                {
+                    "key": "dcatap:availability"
+                },
+                {
+                    "key": "bv:archivalValue",
+                    "inlinetitle": "Check this box if the dataset should be archived"
+                },
+                {
+                    "key": "bv:retentionPeriod"
+                },
+                {
+                    "key": "dcatap:availability"
                 }
             ]
         },
@@ -78,6 +125,71 @@
                 },
                 {
                     "key": "dct:accrualPeriodicity"
+                }
+            ]
+        },
+        {
+            "type": "fieldset",
+            "title": "Distributions",
+            "expandable": false,
+            "items": [
+                {
+                    "type": "tabarray",
+                    "items": [
+                      {
+                        "type": "section",
+                        "legend": "{{idx}}. {{value}}",
+                        "items": [
+                            {
+                                "key": "dcat:distribution[].dct:title.de",
+                                "type": "text",
+                                "title": "Title (German)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:title.fr",
+                                "type": "text",
+                                "title": "Title (French)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:title.it",
+                                "type": "text",
+                                "title": "Title (Italian)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:title.en",
+                                "type": "text",
+                                "title": "Title (English)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:description.de",
+                                "type": "textarea",
+                                "title": "Description (German)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:description.fr",
+                                "type": "textarea",
+                                "title": "Description (French)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:description.it",
+                                "type": "textarea",
+                                "title": "Description (Italian)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:description.en",
+                                "type": "textarea",
+                                "title": "Description (English)"
+                            },
+                            {
+                                "key": "dcat:distribution[].dcat:accessURL"
+                            },
+                            {
+                                "key": "dcat:distribution[].dct:format",
+                                "valueInLegend": true
+                            }
+                        ]
+                      }
+                    ]
                 }
             ]
         }

--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -46,17 +46,24 @@
             ]
           },
           {
+            "key": "dcat:theme",
+            "type": "array",
+            "items": {
+              "key": "dcat:theme[]",
+              "type": "text",
+              "notitle": true,
+              "placeholder": "Enter a keyword"
+            }
+          },
+          {
             "key": "dcat:keyword",
             "type": "array",
             "items": {
               "key": "dcat:keyword[]",
               "type": "text",
+              "notitle": true,
               "placeholder": "Enter a keyword"
             }
-          },
-          {
-            "key": "dcat:theme",
-            "type": "array"
           }
         ]
       },
@@ -92,7 +99,7 @@
         "items": [
           {
             "key": "bv:archivalValue",
-            "inlinetitle": "Is this dataset archival?"
+            "inlinetitle": "Should this dataset be (eventually) archived?"
           },
           {
             "key": "bv:retentionPeriod",
@@ -225,15 +232,33 @@
         "items": [
           {
             "key": "dcatap:applicableLegislation",
-            "type": "array"
+            "type": "array",
+            "items": {
+              "key": "dcatap:applicableLegislation[]",
+              "type": "text",
+              "notitle": true,
+              "placeholder": "Enter the URL of an applicable legislation (e.g., https://www.fedlex.admin.ch/eli/oc/2022/491/de#art_5)"
+            }
           },
           {
             "key": "prov:wasGeneratedBy",
-            "type": "array"
+            "type": "array",
+            "items": {
+              "key": "prov:wasGeneratedBy[]",
+              "type": "text",
+              "notitle": true,
+              "placeholder": "<TO BE COMPLETED>"
+            }
           },
           {
             "key": "prov:wasDerivedFrom",
-            "type": "array"
+            "type": "array",
+            "items": {
+              "key": "prov:wasDerivedFrom[]",
+              "type": "text",
+              "notitle": true,
+              "placeholder": "<TO BE COMPLETED>"
+            }
           }
         ]
       },

--- a/docs/assets/js/commit.js
+++ b/docs/assets/js/commit.js
@@ -1,0 +1,123 @@
+$(document).ready(function() {
+    
+    const API_BASE = 'https://api.github.com';
+    const OWNER = 'blw-ofag-ufag';
+    const REPO = 'metadata';
+    const BRANCH = 'main'; // or "refs/heads/main"
+  
+    // Retrieve data from sessionStorage
+    let jsonDataStr = sessionStorage.getItem('jsonData');
+    let datasetId = sessionStorage.getItem('datasetId');
+  
+    if (!jsonDataStr || !datasetId) {
+      $('#result').text(
+        'No dataset JSON found in session. Please go back and submit a dataset first.'
+      );
+      $('#commit-btn').prop('disabled', true);
+      return;
+    }
+  
+    const jsonData = JSON.parse(jsonDataStr);
+  
+    function utf8ToB64(str) {
+      const encoder = new TextEncoder();
+      const bytes = encoder.encode(str);
+      let binary = '';
+      bytes.forEach(byte => {
+        binary += String.fromCharCode(byte);
+      });
+      return window.btoa(binary);
+    }
+    const newContentBase64 = utf8ToB64(JSON.stringify(jsonData, null, 2));
+  
+    // Path: data/raw/datasets/<ID>.json
+    const filePath = `data/raw/datasets/${datasetId}.json`;
+  
+    // Return to home button
+    $('#home-btn').on('click', function() {
+      window.location.href = 'index.html';
+    });
+  
+    // Commit button
+    $('#commit-btn').on('click', function() {
+      const username = $('#gh-username').val().trim();
+      const token = $('#gh-token').val().trim();
+      const commitMsg = $('#commit-message').val().trim() || 'Update dataset';
+  
+      if (!username || !token) {
+        $('#result').text('Please enter your GitHub username and token.');
+        return;
+      }
+  
+      // 1) Check if file already exists => GET for the file
+      const getUrl = `${API_BASE}/repos/${OWNER}/${REPO}/contents/${filePath}?ref=${BRANCH}`;
+  
+      $.ajax({
+        url: getUrl,
+        method: 'GET',
+        headers: {
+          'Authorization': 'token ' + token,
+          'Accept': 'application/vnd.github.v3+json'
+        },
+        success: function(data) {
+          // File exists => we have data.sha
+          const existingSha = data.sha;
+          commitFile(existingSha);
+        },
+        error: function(xhr) {
+          if (xhr.status === 404) {
+            // File does not exist => create new
+            commitFile(null);
+          } else {
+            $('#result').text(
+              `Error checking file existence: ${xhr.status}\n${xhr.responseText}`
+            );
+          }
+        }
+      });
+  
+      // 2) Create or update the file
+      function commitFile(sha) {
+        const putUrl = `${API_BASE}/repos/${OWNER}/${REPO}/contents/${filePath}`;
+  
+        const payload = {
+          message: commitMsg,
+          committer: {
+            name: username,
+            email: username + '@users.noreply.github.com'
+          },
+          content: newContentBase64,
+          branch: BRANCH
+        };
+  
+        if (sha) {
+          payload.sha = sha;
+        }
+  
+        $.ajax({
+          url: putUrl,
+          method: 'PUT',
+          data: JSON.stringify(payload),
+          headers: {
+            'Authorization': 'token ' + token,
+            'Content-Type': 'application/json',
+            'Accept': 'application/vnd.github.v3+json'
+          },
+          success: function(response) {
+            // success => Show link to the new/updated file
+            const fileUrl = response.content.html_url;
+            const anchor = `<a href="${fileUrl}" target="_blank">${fileUrl}</a>`;
+            $('#result').html(
+              'Commit successful!<br /><br />' +
+              'View file on GitHub:<br />' + anchor
+            );
+          },
+          error: function(xhr) {
+            $('#result').text(
+              `Error committing file: ${xhr.status}\n${xhr.responseText}`
+            );
+          }
+        });
+      }
+    });
+});

--- a/docs/assets/js/details.js
+++ b/docs/assets/js/details.js
@@ -79,7 +79,7 @@ function renderActionButtons(datasetId, lang) {
   const rawUrl = `https://raw.githubusercontent.com/blw-ofag-ufag/metadata/main/data/raw/datasets/${datasetId}.json`;
   document.getElementById("downloadBtn").setAttribute("href", rawUrl);
   document.getElementById("viewOnGithubBtn").setAttribute("href", gitHubUrl);
-  // document.getElementById("editBtn").setAttribute("href", `modify.html?id=${datasetId}&lang=${lang}`);
+  document.getElementById("editBtn").setAttribute("href", `modify.html?dataset=${datasetId}&lang=${lang}`);
 }
 
 function renderAffiliatedPersons(data, lang) {

--- a/docs/assets/js/modify.js
+++ b/docs/assets/js/modify.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
   }
 
   // Extract dataset id from the URL parameter 'id'
-  var datasetId = getParameterByName('id');
+  var datasetId = getParameterByName('dataset');
 
   // Points to your local form definition
   var formUrl = 'assets/forms.json';

--- a/docs/assets/js/modify.js
+++ b/docs/assets/js/modify.js
@@ -6,7 +6,7 @@ $(document).ready(function() {
   var schemaUrl = 'https://raw.githubusercontent.com/blw-ofag-ufag/metadata/main/data/schemas/dataset.json';
 
   // 3. Points to your existing JSON (to edit)
-  var dataUrl = 'https://raw.githubusercontent.com/blw-ofag-ufag/metadata/main/data/raw/datasets/2ea8bfa1-8bb6-45ef-bee4-3b4cba52d834.json';
+  var dataUrl = 'https://raw.githubusercontent.com/blw-ofag-ufag/metadata/main/data/raw/datasets/83f93ff4-ef3f-43f1-af2c-83f18952283e.json';
 
   // Fetch the form definition
   $.getJSON(formUrl, function(formDefinition) {

--- a/docs/assets/js/modify.js
+++ b/docs/assets/js/modify.js
@@ -9,10 +9,42 @@ $(document).ready(function() {
     if (!results[2]) return '';
     return decodeURIComponent(results[2].replace(/\+/g, ' '));
   }
-  
+
+  // Helper function to generate a UUID (version 4)
+  function generateUUID() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      const r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
+  }
+
+  /**
+   * Takes a JavaScript object and returns a new object
+   * with "dct:identifier" at the top if it exists. 
+   */
+  function reorderIdentifierFirst(obj) {
+    if (!obj || typeof obj !== 'object') return obj;
+
+    // Create a new object for safe reordering
+    let newObj = {};
+
+    // If there's a dct:identifier, set it first
+    if (obj.hasOwnProperty('dct:identifier')) {
+      newObj['dct:identifier'] = obj['dct:identifier'];
+    }
+
+    // Add the remaining properties
+    for (let key in obj) {
+      if (key !== 'dct:identifier') {
+        newObj[key] = obj[key];
+      }
+    }
+    return newObj;
+  }
+
   // Extract dataset id from the URL parameter 'id'
   var datasetId = getParameterByName('id');
-  
+
   // Points to your local form definition
   var formUrl = 'assets/forms.json';
   // Points to your remote schema
@@ -51,12 +83,32 @@ $(document).ready(function() {
             if (errors) {
               alert('Please correct the errors in the form.');
             } else {
+              // 1. Ensure top-level dct:identifier
+              if (!values['dct:identifier']) {
+                values['dct:identifier'] = generateUUID();
+              }
+
+              // 2. Ensure distribution-level dct:identifier
+              if (values['dcat:distribution'] && Array.isArray(values['dcat:distribution'])) {
+                values['dcat:distribution'].forEach(function(distribution, i) {
+                  if (!distribution['dct:identifier']) {
+                    distribution['dct:identifier'] = generateUUID();
+                  }
+                  // Reorder each distribution so that dct:identifier is at top
+                  values['dcat:distribution'][i] = reorderIdentifierFirst(distribution);
+                });
+              }
+
+              // 3. Reorder top-level object so dct:identifier is first
+              values = reorderIdentifierFirst(values);
+
+              // 4. Display the resulting JSON
               $('#result').text(JSON.stringify(values, null, 2));
             }
           }
         });
       }
-      
+
       // Check if a dataset ID was provided in the URL
       if (datasetId) {
         // Construct the URL for the existing data based on the dataset ID

--- a/docs/assets/js/modify.js
+++ b/docs/assets/js/modify.js
@@ -1,37 +1,63 @@
 $(document).ready(function() {
-    // URL of the external JSON schema
-    var schemaUrl = 'https://raw.githubusercontent.com/blw-ofag-ufag/data-catalog/refs/heads/main/docs/assets/forms.json';
-  
-    // Fetch the external schema
-    $.getJSON(schemaUrl, function(data) {
-      // Add submit button to the form definition if not present
-      if (!data.form.some(item => item.type === 'actions')) {
-        data.form.push({
-          type: 'actions',
-          items: [
-            {
-              type: 'submit',
-              value: 'Submit'
-            }
-          ]
-        });
-      }
-  
-      // Initialize the form
-      $('#my-form').jsonForm({
-        schema: data.schema,
-        form: data.form,
-        onSubmit: function (errors, values) {
-          if (errors) {
-            alert('Please correct the errors in the form.');
-          } else {
-            // Display the generated JSON in the <pre> element
-            $('#result').text(JSON.stringify(values, null, 2));
-          }
+  // 1. Points to your local form definition (which may contain "form": [...] etc.)
+  var formUrl = 'assets/forms.json';
+
+  // 2. Points to your remote schema
+  var schemaUrl = 'https://raw.githubusercontent.com/blw-ofag-ufag/metadata/main/data/schemas/dataset.json';
+
+  // 3. Points to your existing JSON (to edit)
+  var dataUrl = 'https://raw.githubusercontent.com/blw-ofag-ufag/metadata/main/data/raw/datasets/2ea8bfa1-8bb6-45ef-bee4-3b4cba52d834.json';
+
+  // Fetch the form definition
+  $.getJSON(formUrl, function(formDefinition) {
+
+    // Fetch the remote schema
+    $.getJSON(schemaUrl, function(schemaData) {
+
+      // Fetch the existing data
+      $.getJSON(dataUrl, function(existingData) {
+
+        // Insert the schema from GitHub into your form definition
+        formDefinition.schema = schemaData;
+
+        // Insert the existing data into your form definition
+        formDefinition.value = existingData;
+
+        // Optionally ensure a submit button is in the form:
+        if (!formDefinition.form.some(item => item.type === 'actions')) {
+          formDefinition.form.push({
+            type: 'actions',
+            items: [
+              {
+                type: 'submit',
+                value: 'Submit'
+              }
+            ]
+          });
         }
+
+        // Initialize the form
+        $('#my-form').jsonForm({
+          schema: formDefinition.schema,
+          form: formDefinition.form,
+          // "value" attribute – used to pre-fill the form
+          value: formDefinition.value,
+          onSubmit: function (errors, values) {
+            if (errors) {
+              alert('Please correct the errors in the form.');
+            } else {
+              $('#result').text(JSON.stringify(values, null, 2));
+            }
+          }
+        });
+
+      }).fail(function() {
+        alert('Failed to load existing data.');
       });
     }).fail(function() {
-      alert('Failed to load the schema. Please check the URL and try again.');
+      alert('Failed to load the remote schema.');
     });
+  }).fail(function() {
+    alert('Failed to load the form definition.');
   });
-  
+});

--- a/docs/commit.html
+++ b/docs/commit.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Commit to GitHub</title>
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Commit Dataset to GitHub</h1>
+
+    <div>
+      <label for="gh-username">GitHub Username:</label><br>
+      <input type="text" id="gh-username" class="form-control" placeholder="e.g. JohnDoe" />
+    </div>
+    <div>
+      <label for="gh-token">Personal Access Token:</label><br>
+      <input type="password" id="gh-token" class="form-control" placeholder="Your PAT" />
+    </div>
+    <div>
+      <label for="commit-message">Commit Message:</label><br>
+      <input type="text" id="commit-message" class="form-control" placeholder="Describe your changes" />
+    </div>
+    <br />
+
+    <button id="commit-btn" class="btn btn-primary">Commit to GitHub</button>
+    <button id="home-btn" class="btn btn-default" style="margin-left: 10px;">Return to Home</button>
+
+    <hr />
+    <div id="result" style="white-space: pre-wrap; margin-top:20px;"></div>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="assets/js/commit.js"></script>
+</body>
+</html>

--- a/docs/commit.html
+++ b/docs/commit.html
@@ -1,30 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
+<head></head>
   <meta charset="UTF-8">
   <title>Commit to GitHub</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"  rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body>
-  <div class="container">
-    <h1>Commit Dataset to GitHub</h1>
+<body>
 
+  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+    <div class="container">
+       <a class="navbar-brand" href="index.html">
+         DigiAgriFoodCH Data Catalog
+       </a>
+       <div class="ms-auto align-items-right">
+          <div class="dropdown">
+             <button class="btn unified-control dropdown-toggle">English</button>
+          </div>
+       </div>
+    </div>
+  </nav>
+
+  <section class="hero-banner">
+    <h1 data-i18n="heroBannerHeading">Commit Dataset to GitHub</h1>
+    <p class="lead" data-i18n="heroBannerText">
+       Final step: Enter your GitHub credentials in order to save the changes you've made.
+       If you don't have any credentials yet, try to reach out to the competence centre for digital transformation at the FOAG.
+    </p>
+ </section>
+
+  <div class="container">
+    <br>
     <div>
       <label for="gh-username">GitHub Username:</label><br>
       <input type="text" id="gh-username" class="form-control" placeholder="e.g. JohnDoe" />
     </div>
+    <br>
     <div>
       <label for="gh-token">Personal Access Token:</label><br>
       <input type="password" id="gh-token" class="form-control" placeholder="Your PAT" />
     </div>
+    <br>
     <div>
       <label for="commit-message">Commit Message:</label><br>
       <input type="text" id="commit-message" class="form-control" placeholder="Describe your changes" />
     </div>
     <br />
 
-    <button id="commit-btn" class="btn btn-primary">Commit to GitHub</button>
-    <button id="home-btn" class="btn btn-default" style="margin-left: 10px;">Return to Home</button>
+    <button id="commit-btn" class="btn btn-primary">Commit changes to GitHub</button>
+    <button id="home-btn" class="btn btn-default" style="margin-left: 10px;">Return to the main page</button>
 
     <hr />
     <div id="result" style="white-space: pre-wrap; margin-top:20px;"></div>

--- a/docs/details.html
+++ b/docs/details.html
@@ -25,7 +25,7 @@
     <div class="container text-end my-3" id="actionButtons">
       <a id="viewOnGithubBtn" class="btn btn-secondary action-btn me-2" href="#" target="_blank"><i class="bi bi-github fs-4"></i></a>
       <a id="downloadBtn" class="btn btn-secondary action-btn me-2" href="#" download><i class="bi bi-filetype-json fs-4"></i></a>
-      <!-- <a id="editBtn" class="btn btn-secondary action-btn" href="#"><i class="bi bi-pencil fs-4"></i></a> -->
+      <a id="editBtn" class="btn btn-secondary action-btn" href="#"><i class="bi bi-pencil fs-4"></i></a>
     </div>
 
     <!-- Main Section -->

--- a/docs/modify.html
+++ b/docs/modify.html
@@ -3,16 +3,49 @@
 <head>
   <meta charset="UTF-8">
   <title>Dataset Metadata Form</title>
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"  rel="stylesheet" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body>
+
+  <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top">
+    <div class="container">
+       <a class="navbar-brand" href="index.html">
+         DigiAgriFoodCH Data Catalog
+       </a>
+       <div class="ms-auto align-items-right">
+          <div class="dropdown">
+             <button class="btn unified-control dropdown-toggle">English</button>
+          </div>
+       </div>
+    </div>
+  </nav>
+
+  <section class="hero-banner">
+     <h1 data-i18n="heroBannerHeading">Dataset Metadata Form</h1>
+     <p class="lead" data-i18n="heroBannerText">
+        In this forms, you'll be able to edit the metadata. Attention: If you don't have the necessary credentials, you won't be able to save any changes made.
+     </p>
+  </section>
+
   <div class="container">
-    <h1>Dataset Metadata Form</h1>
-    <!-- Form will be rendered here -->
+    <br>
     <form id="my-form"></form>
+    <br>
   </div>
+
+  <footer>
+    <section class="py-2">
+      <div class="container d-flex flex-column flex-lg-row justify-content-between align-items-right">
+        <div class="footer-links mb-2 mb-lg-0 d-flex w-100 justify-content-end">
+          <a href="mailto:kompetenzzentrumdigitaletransformation@blw.admin.ch" class="text-light me-3"><i class="bi bi-envelope"></i></a>
+          <a href="https://github.com/blw-ofag-ufag/data-catalog" class="text-light me-3"><i class="bi bi-github"></i></a>
+        </div>
+      </div>
+    </section>
+  </footer>
 
   <!-- Include necessary libraries -->
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>

--- a/docs/modify.html
+++ b/docs/modify.html
@@ -3,8 +3,9 @@
 <head>
   <meta charset="UTF-8">
   <title>Dynamic JSON Form</title>
-  <!-- Include Bootstrap CSS for styling -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body>
   <div class="container">

--- a/docs/modify.html
+++ b/docs/modify.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Dynamic JSON Form</title>
+  <title>Dataset Metadata Form</title>
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/css/style.css" />
@@ -12,9 +12,6 @@
     <h1>Dataset Metadata Form</h1>
     <!-- Form will be rendered here -->
     <form id="my-form"></form>
-    <!-- Container to display the generated JSON -->
-    <h2>Generated JSON</h2>
-    <pre id="result"></pre>
   </div>
 
   <!-- Include necessary libraries -->
@@ -22,7 +19,7 @@
   <script src="https://underscorejs.org/underscore-min.js"></script>
   <script src="https://cdn.jsdelivr.net/gh/jsonform/jsonform@2.2.5/lib/jsonform.js"></script>
 
-  <!-- Include external JavaScript file -->
+  <!-- Your modify.js script -->
   <script src="assets/js/modify.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#28

- Add mechanism to edit metadata files.
- Add mechanism to create a new metadata file.
- Delete option is still missing (will have to think about how to do this yet.)

The mechanism looks as follows:

1. User can edit/create dataset metadata on modify.html
2. Clicking submit will save JSON to session and open commit.html
3. There, username and password need to be entered, which creates the commit to GitHub.
4. Upon successful commit, a corresponding message is shown to the user.

@AFoletti I'll gladly do a short system demo if you want.