### PR TITLE
Allow dcat:theme to be enumerated

### DIFF
--- a/docs/assets/forms.json
+++ b/docs/assets/forms.json
@@ -52,7 +52,6 @@
             "type": "array",
             "items": {
               "key": "dcat:theme[]",
-              "type": "text",
               "notitle": true,
               "placeholder": "Enter a keyword"
             }


### PR DESCRIPTION
Removing the `"type": "text",` line allows the enumerated types to be fetched.