### PR TITLE
Translations change repository

### DIFF
--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -423,6 +423,7 @@
           "next": "Suivant",
           "previous": "Précédent"
         },
+        "changeRepository": "Changer le dépôt",
         "reset": "Réinitialiser",
         "submit": "Vérifier",
         "buttons": {

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -423,6 +423,7 @@
           "next": "Avanti",
           "previous": "Indietro"
         },
+        "changeRepository": "Cambiare repository",
         "reset": "Ripristina",
         "submit": "Verifica",
         "buttons": {


### PR DESCRIPTION
added translation for labels when changing the repository. French and italian defaulted to the german text.

<img width="811" height="357" alt="image" src="https://github.com/user-attachments/assets/418166d6-c5f7-4760-a240-c5ae02e55186" />
