### PR TITLE
fix: display prov:wasDerivedFrom as linked dataset titles (#261)

### DIFF
--- a/src/app/details/metadata/metadata-item.component.ts
+++ b/src/app/details/metadata/metadata-item.component.ts
@@ -234,33 +234,6 @@ export class WasGeneratedByComponent {
 
 @Component({
 	template:
-		'<p>{{ data[0] }} - <a (mouseup)="navigateToDataset(data[1])" style="cursor: pointer; text-decoration: underline; color: #0066cc;">{{ data[1] }}</a></p>',
-	standalone: true
-})
-export class WasDerivedFromComponent {
-	data: string[] = [];
-	private readonly route: ActivatedRoute;
-	private readonly router: Router;
-
-	constructor(private readonly injector: Injector) {
-		this.data = this.injector.get('data', []);
-		this.route = this.injector.get(ActivatedRoute);
-		this.router = this.injector.get(Router);
-	}
-
-	navigateToDataset(datasetId: string) {
-		const currentParams = this.route.snapshot.queryParams;
-		const queryParams = {
-			publisher: currentParams['publisher'],
-			dataset: datasetId,
-			lang: currentParams['lang']
-		};
-		this.router.navigate(['/details'], {queryParams});
-	}
-}
-
-@Component({
-	template:
 		'<ul>@for (item of data; track $index) {<li><a [href]="item.uri" target="_blank" rel="noopener noreferrer" (mouseup)="onMouseUp($event, item.uri)" style="cursor: pointer;">{{item.alias || item.uri}}</a></li>}</ul>',
 	styles: 'ul {list-style-type: none; padding: 0; margin: 0; padding-inline-start: 0;}',
 	standalone: true
@@ -296,12 +269,13 @@ export class DatasetIdListComponent {
 	template: `<ul>
 		@for (id of data; track $index) {
 			<li>
-				<a (mouseup)="navigateToDataset(id)" style="cursor: pointer; text-decoration: underline; color: #0066cc;">{{ getDatasetTitle(id) || id }}</a>
+				<a [routerLink]="['/details']" [queryParams]="getQueryParams(id)" (mouseup)="navigateToDataset(id)" style="cursor: pointer;">{{ getDatasetTitle(id) || id }}</a>
 			</li>
 		}
 	</ul>`,
 	styles: 'ul {list-style-type: none; padding: 0; margin: 0; padding-inline-start: 0;}',
-	standalone: true
+	standalone: true,
+	imports: [RouterLink]
 })
 export class DatasetLinkListComponent implements OnInit, OnDestroy {
 	data: string[] = [];
@@ -321,6 +295,10 @@ export class DatasetLinkListComponent implements OnInit, OnDestroy {
 	}
 
 	ngOnInit(): void {
+		// Ensure the dataset index is available so reference IDs can be resolved to
+		// titles even when the details page was deep-linked (index never visited).
+		this.multiDatasetService.ensureIndexLoaded();
+
 		// Subscribe to datasets to lookup titles
 		this.multiDatasetService.datasets$
 			.pipe(takeUntil(this.destroy$))
@@ -354,14 +332,20 @@ export class DatasetLinkListComponent implements OnInit, OnDestroy {
 		return '';
 	}
 
-	navigateToDataset(datasetId: string) {
+	getQueryParams(datasetId: string) {
 		const currentParams = this.route.snapshot.queryParams;
-		const queryParams = {
+		return {
 			publisher: currentParams['publisher'],
 			dataset: datasetId,
 			lang: currentParams['lang']
 		};
-		this.router.navigate(['/details'], {queryParams});
+	}
+
+	// Navigation happens on mouseup (matching the other detail-page links), since
+	// plain click navigation is intercepted in this view. routerLink is kept only
+	// to render a real href so the anchor gets normal link styling (hover/visited).
+	navigateToDataset(datasetId: string) {
+		this.router.navigate(['/details'], {queryParams: this.getQueryParams(datasetId)});
 	}
 }
 
@@ -419,6 +403,7 @@ export class MetadataItemComponent {
 				return DateMetadataItemComponent;
 			case 'dcat:inSeries':
 			case 'dct:replaces':
+			case 'prov:wasDerivedFrom':
 				return DatasetLinkListComponent;
 			case 'dcat:contactPoint':
 				return ContactPointComponent;
@@ -426,8 +411,6 @@ export class MetadataItemComponent {
 				return TemporalComponent;
 			case 'prov:wasGeneratedBy':
 				return WasGeneratedByComponent;
-			case 'prov:wasDerivedFrom':
-				return WasDerivedFromComponent;
 		}
 
 		// Handle URL links

--- a/src/app/services/api/multi-dataset-service.service.ts
+++ b/src/app/services/api/multi-dataset-service.service.ts
@@ -44,11 +44,22 @@ export class MultiDatasetService {
 			// path.publisher = 'BLW-OFAG-UFAG-FOAG';
 			this.loadDetail(path.publisher, path.klass, path.id);
 		} else {
-			if (!this.indexLoaded) {
-				this.loadIndex();
-				this.indexLoaded = true;
-			}
+			this.ensureIndexLoaded();
 		}
+	}
+
+	/**
+	 * Loads the full dataset index once (idempotent). Used both on the index route
+	 * and by detail-page components that need to resolve dataset references (e.g.
+	 * titles for prov:wasDerivedFrom / dcat:inSeries / dct:replaces) when the page
+	 * was deep-linked without first visiting the index.
+	 */
+	ensureIndexLoaded() {
+		if (this.indexLoaded) {
+			return;
+		}
+		this.indexLoaded = true;
+		this.loadIndex();
 	}
 
 	loadIndex() {


### PR DESCRIPTION
Closes #261

## Problem

On the dataset details page, `prov:wasDerivedFrom` rendered incorrectly. The field is an **array of dataset IDs** (already `string[]` in the schema), but it was routed to a dedicated component that treated the value as a single `[x, id]` tuple — so it showed at most one entry, never resolved titles, and couldn't point to multiple datasets.

## Fix

- **Display:** route `prov:wasDerivedFrom` to `DatasetLinkListComponent` — the same component already used for `dcat:inSeries` / `dct:replaces` — and remove the now-unused `WasDerivedFromComponent`. It renders a list of clickable dataset links and supports multiple sources.
- **Styling:** render the links as real `routerLink` anchors (so they get an `href` and inherit normal link styling incl. hover/visited), dropping the hardcoded inline blue/underline. Navigation stays on `(mouseup)` to match the other detail-page links (plain click navigation is intercepted in this view).
- **Title resolution:** resolve reference IDs to titles even on deep-linked detail pages via a new idempotent `ensureIndexLoaded()` on `MultiDatasetService`. This also fixes title resolution for `dcat:inSeries` / `dct:replaces`.

## Out of scope

Entering *multiple* source datasets via the **edit form** (currently a single text input, same as `inSeries`/`replaces`) is the dataset-reference multi-select tracked under #221.

## Verification

- `npm run build` passes.
- Manual: open a dataset with `prov:wasDerivedFrom` (e.g. the example in #261) — it now shows a list of clickable, title-resolved dataset links styled like the other links; clicking navigates to the referenced dataset.