### PR TITLE
fix(styles): restore readable chip label text after Oblique 15 upgrade

### DIFF
--- a/src/styles/_chips.scss
+++ b/src/styles/_chips.scss
@@ -1,0 +1,15 @@
+// Oblique 15 / Angular Material 21 theme standard chips as `mat-primary`, which sets the MDC label
+// text token (--mat-chip-label-text-color) to white. The catalog's chips sit on light backgrounds,
+// so every chip whose text isn't wrapped in a separately-coloured <a> turned white-on-light and
+// unreadable — e.g. the "+n" keyword-overflow chip in cards and the filter/keyword chips.
+//
+// Restore a readable dark label for standard chips, while leaving Oblique's semantic chips
+// (info/success/error/warning) and genuinely selected chips (dark background) with their white text.
+.mat-mdc-standard-chip:not(.info):not(.success):not(.error):not(.warning):not(.mat-mdc-chip-selected):not(.more-chip) {
+	--mat-chip-label-text-color: rgba(0, 0, 0, 0.87);
+}
+
+// The keyword-overflow chip is intentionally muted grey.
+.more-chip {
+	--mat-chip-label-text-color: #6b7280 !important;
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -1,2 +1,3 @@
 // this file should contain only imports. Rules should be grouped by features and placed into the corresponding file
 @use 'datepicker';
+@use 'chips';


### PR DESCRIPTION
## Problem

After the Oblique 14→15 upgrade (#274), several pills/tags render with **white text on a light background** and are unreadable — e.g. the `+n` keyword-overflow chip in cards and theme/keyword chips (`Thema: Landwirtschaft`).

## Root cause

Oblique 15 / Angular Material 21 theme standard chips as `mat-primary`, whose theme sets the MDC label token `--mat-chip-label-text-color` to **white**. The catalog's chips sit on light surfaces. Chips whose text happened to be wrapped in an `<a>` (with its own `color: black`) stayed readable, which masked the issue; every link-less chip (the `+n` overflow chip, filter keyword chips, detail theme chips) turned white-on-light.

The component SCSS sets `color` on the chip **host** with `!important`, but Material renders the text in a nested `.mdc-evolution-chip__text-label` that reads the token — so the host color never reached it.

## Fix

`src/styles/_chips.scss` (new, wired via `styles.scss`): override `--mat-chip-label-text-color` to a readable dark for standard chips, keep the overflow chip muted grey, and **exclude** Oblique's semantic chips (`info/success/error/warning`) and genuinely selected (dark-background) chips so their intended white text is preserved.

## Verification (headless Chromium, real render)

Confirmed computed label color flips from `rgb(255,255,255)` → `rgba(0,0,0,.87)` (grey `#6b7280` for `+n`), across:
- **Cards**: keyword chips + the `+n` overflow chip (was invisible, now legible)
- **Filter panel**: keyword/facet chips
- **Detail page**: all theme/keyword chips (incl. `Agriculture`/`Landwirtschaft`)

Production build passes.