### PR TITLE
fix(#259): stop showing catalog dates one day early

### DIFF
--- a/src/app/details/metadata/date-metadata-item.component.html
+++ b/src/app/details/metadata/date-metadata-item.component.html
@@ -1,1 +1,1 @@
-{{ data | date: "d. MMMM y" : "UTC" : locale }}
+{{ data | date: "d. MMMM y" : undefined : locale }}

--- a/src/app/details/metadata/date-metadata-item.component.spec.ts
+++ b/src/app/details/metadata/date-metadata-item.component.spec.ts
@@ -1,0 +1,34 @@
+// Pin the timezone BEFORE anything reads it: this regression must fail on a Swiss
+// (UTC+1/+2) clock, which is the actual audience. On a UTC CI runner the off-by-one
+// is invisible, so we force Europe/Zurich here (see issue #259).
+process.env.TZ = 'Europe/Zurich';
+
+import {DatePipe, registerLocaleData} from '@angular/common';
+import localeDeCh from '@angular/common/locales/de-CH';
+
+registerLocaleData(localeDeCh);
+
+/**
+ * Issue #259: catalog dates were shown one day early. Stored values are date-only
+ * strings (e.g. "2026-07-02"), which Angular's DatePipe parses as LOCAL midnight.
+ * Passing the "UTC" timezone (as an earlier fix did) then rolls that instant back
+ * across midnight for any timezone east of UTC — the previous calendar day. The
+ * correct rendering for a date-only value passes NO timezone, so it shows the literal
+ * day everywhere. This test locks that in, and documents that "UTC" reintroduces the bug.
+ */
+describe('date-only rendering (issue #259)', () => {
+	const pipe = new DatePipe('de-CH');
+	const format = 'd. MMMM y';
+
+	it('renders a date-only string as its literal day when no timezone is forced', () => {
+		expect(pipe.transform('2026-07-02', format, undefined, 'de-CH')).toBe('2. Juli 2026');
+		expect(pipe.transform('2026-07-05', format, undefined, 'de-CH')).toBe('5. Juli 2026');
+		expect(pipe.transform('1997-01-01', format, undefined, 'de-CH')).toBe('1. Januar 1997');
+	});
+
+	it('demonstrates that forcing "UTC" shifts a date-only value back one day on a Swiss clock (the bug)', () => {
+		// This asserts the WRONG output on purpose, to prove the TZ pin is effective and
+		// to pin the reason the templates must not pass "UTC" for date-only fields.
+		expect(pipe.transform('2026-07-02', format, 'UTC', 'de-CH')).toBe('1. Juli 2026');
+	});
+});

--- a/src/app/details/metadata/temporal-metadata-item.component.html
+++ b/src/app/details/metadata/temporal-metadata-item.component.html
@@ -1,1 +1,1 @@
-{{ data["dcat:start_date"] | date: "d. MMMM y" : "UTC" : locale }} - {{ data["dcat:end_date"] | date: "d. MMMM y" : "UTC" : locale }}
+{{ data["dcat:start_date"] | date: "d. MMMM y" : undefined : locale }} - {{ data["dcat:end_date"] | date: "d. MMMM y" : undefined : locale }}

--- a/src/app/index-cards/index-cards.component.html
+++ b/src/app/index-cards/index-cards.component.html
@@ -37,7 +37,7 @@
 				</mat-card-subtitle>
 			</mat-card-header>
 			<mat-card-content>
-				{{ "ui.issueDate" | translate }}: {{ dataset["dct:issued"] | date: "d. MMMM y" : "UTC" : (currentLang$ | async)! }} <br /><br />
+				{{ "ui.issueDate" | translate }}: {{ dataset["dct:issued"] | date: "d. MMMM y" : undefined : (currentLang$ | async)! }} <br /><br />
 				<div [class]="getChipContainerClass(dataset['dct:identifier'])">
 					<!-- Show visible keywords when collapsed, or all keywords when expanded -->
 					@if (isExpanded(dataset["dct:identifier"])) {

--- a/src/app/index-list/index-list.component.html
+++ b/src/app/index-list/index-list.component.html
@@ -11,7 +11,7 @@
 		@for (dataset of datasets$ | async; track $index) {
 			<tr (click)="openDataset(dataset['dct:publisher'], dataset['dct:identifier'])" style="cursor: pointer">
 				<td data-title="Title">{{ ["dct:title", dataset["dct:title"]] | translateField }}</td>
-				<td data-title="Issued" class="no-wrap">{{ dataset["dct:issued"] | date: "shortDate" : "UTC" : translate.currentLang }}</td>
+				<td data-title="Issued" class="no-wrap">{{ dataset["dct:issued"] | date: "shortDate" : undefined : translate.currentLang }}</td>
 				<td data-title="Steward" class="no-wrap">
 					<div class="ob-flex ob-flex-wrap ob-gap-2">
 						@for (steward of getStewards(dataset); track $index) {


### PR DESCRIPTION
## Problem
Catalog dates (`dct:issued`, `dct:modified`, temporal coverage) were displayed **one day early** for Swiss users — e.g. a stored `dct:issued: "2026-07-02"` showed as *1. Juli 2026* on the details page (issue #259, latest report).

## Root cause
Date values are stored as **date-only** strings (`YYYY-MM-DD`). Angular's `DatePipe` parses a bare date-only string as **local midnight**. The templates then forced the `"UTC"` timezone, which rolls that local-midnight instant back across midnight for every timezone **east of UTC** — i.e. all of Switzerland (UTC+1/+2) — yielding the previous calendar day.

The `"UTC"` argument was introduced in `8ce3bfa` while correcting the pipe's argument positions (the locale had previously been passed in the timezone slot). It looked correct only because timezones *west* of UTC render the same day either way.

## Fix
Drop the forced `"UTC"` timezone (keep the locale argument via `undefined`) at every date-render site, so a date-only value renders its literal calendar day in any timezone:

- `details/metadata/date-metadata-item.component.html`
- `details/metadata/temporal-metadata-item.component.html`
- `index-cards/index-cards.component.html`
- `index-list/index-list.component.html`

## Test
Adds a `DatePipe` regression test pinned to `Europe/Zurich` (so the off-by-one is caught even on a UTC CI runner). It asserts the fix renders `2. Juli 2026` and documents that `"UTC"` reproduces the `1. Juli 2026` bug.

## Verification
- Regression test passes (2/2).
- AOT dev build compiles the `undefined`-timezone pipe change cleanly.
- Confirmed the affected record's data is correct in both the raw file and processed index — this is display-only; serialization is untouched.

Refs #259. (Issue stays open for testing — do not auto-close.)
