### PR TITLE
fix(#260): write external catalogs in the schema shape, stop dropping them on edit

### DIFF
--- a/src/app/details/details.component.html
+++ b/src/app/details/details.component.html
@@ -152,10 +152,12 @@
 					<hr />
 					<table class="ob-table ob-table-plain">
 						<tbody>
+							<!-- Records written by the pre-#260 form stored bare strings instead of
+							     {dcat:catalog, dct:identifier} objects; render those rather than a blank row. -->
 							@for (pub of dataset["bv:externalCatalogs"]; track $index) {
 								<tr>
-									<td>{{ pub["dcat:catalog"] }}</td>
-									<td>{{ pub["dct:identifier"] }}</td>
+									<td>{{ isString(pub) ? pub : pub["dcat:catalog"] }}</td>
+									<td>{{ isString(pub) ? "" : pub["dct:identifier"] }}</td>
 								</tr>
 							}
 						</tbody>

--- a/src/app/details/details.component.ts
+++ b/src/app/details/details.component.ts
@@ -242,6 +242,12 @@ export class DetailsComponent implements OnInit, OnDestroy {
 			.unsubscribe(); // Unsubscribe immediately after getting the value
 	}
 
+	// bv:externalCatalogs entries are {dcat:catalog, dct:identifier} objects per the schema, but
+	// records written by the pre-#260 form stored bare strings. Used to render both shapes.
+	isString(value: unknown): value is string {
+		return typeof value === 'string';
+	}
+
 	getFormatIcon(format: string): string {
 		if (!format) return 'file';
 

--- a/src/app/modify/external-catalogs.util.spec.ts
+++ b/src/app/modify/external-catalogs.util.spec.ts
@@ -1,0 +1,50 @@
+import {normalizeExternalCatalogs} from './external-catalogs.util';
+
+describe('normalizeExternalCatalogs (issue #260)', () => {
+	it('keeps object entries and their externally-assigned dct:identifier', () => {
+		const value = [
+			{'dcat:catalog': 'I14Y', 'dct:identifier': 'admin-dataset-12345'},
+			{'dcat:catalog': 'opendata.swiss', 'dct:identifier': '001-992-334'}
+		];
+
+		expect(normalizeExternalCatalogs(value)).toEqual(value);
+	});
+
+	// The pre-fix form wrote ["I14Y", "opendata.swiss"]. Such records exist upstream, so loading
+	// one must not blow up or silently drop its catalogs.
+	it('upgrades legacy bare-string entries to the schema shape', () => {
+		expect(normalizeExternalCatalogs(['I14Y', 'opendata.swiss'])).toEqual([
+			{'dcat:catalog': 'I14Y', 'dct:identifier': ''},
+			{'dcat:catalog': 'opendata.swiss', 'dct:identifier': ''}
+		]);
+	});
+
+	it('handles a mixed array of both shapes', () => {
+		expect(normalizeExternalCatalogs(['I14Y', {'dcat:catalog': 'geocat.ch', 'dct:identifier': 'g-1'}])).toEqual([
+			{'dcat:catalog': 'I14Y', 'dct:identifier': ''},
+			{'dcat:catalog': 'geocat.ch', 'dct:identifier': 'g-1'}
+		]);
+	});
+
+	it('defaults a missing dct:identifier to an empty string', () => {
+		expect(normalizeExternalCatalogs([{'dcat:catalog': 'I14Y'}])).toEqual([{'dcat:catalog': 'I14Y', 'dct:identifier': ''}]);
+	});
+
+	it.each([
+		['a non-array', 'I14Y'],
+		['null', null],
+		['undefined', undefined],
+		['an empty array', []]
+	])('yields no entries for %s', (_label, value) => {
+		expect(normalizeExternalCatalogs(value)).toEqual([]);
+	});
+
+	it.each([
+		['an entry without a catalog name', [{'dct:identifier': 'orphan'}]],
+		['a blank string entry', ['   ']],
+		['a blank catalog name', [{'dcat:catalog': ''}]],
+		['a null entry', [null]]
+	])('drops %s', (_label, value) => {
+		expect(normalizeExternalCatalogs(value)).toEqual([]);
+	});
+});

--- a/src/app/modify/external-catalogs.util.ts
+++ b/src/app/modify/external-catalogs.util.ts
@@ -1,0 +1,44 @@
+/**
+ * Normalisation for `bv:externalCatalogs` (issue #260).
+ *
+ * The schema declares an array of objects — `dcat:catalog` required, optional `dct:identifier`,
+ * `additionalProperties: false`. The edit form used to write an array of bare catalog names
+ * (`["I14Y", "opendata.swiss"]`), which violates the schema and renders as blank rows on the
+ * detail page. Records written that way exist upstream, so loading must tolerate both shapes.
+ */
+export interface ExternalCatalogEntry {
+	'dcat:catalog': string;
+	'dct:identifier': string;
+}
+
+/**
+ * Coerce a record's `bv:externalCatalogs` value into the schema shape.
+ *
+ * - object entries keep their `dct:identifier` (assigned by the external catalog at first
+ *   publication — losing it would sever the record's link to the published dataset)
+ * - legacy string entries become `{'dcat:catalog': <string>, 'dct:identifier': ''}`
+ * - anything without a catalog name, and any non-array input, yields no entries
+ */
+export function normalizeExternalCatalogs(value: unknown): ExternalCatalogEntry[] {
+	if (!Array.isArray(value)) {
+		return [];
+	}
+
+	const entries: ExternalCatalogEntry[] = [];
+	for (const entry of value) {
+		if (typeof entry === 'string') {
+			if (entry.trim() !== '') {
+				entries.push({'dcat:catalog': entry, 'dct:identifier': ''});
+			}
+			continue;
+		}
+		if (entry && typeof entry === 'object') {
+			const catalog = (entry as Record<string, unknown>)['dcat:catalog'];
+			if (typeof catalog === 'string' && catalog.trim() !== '') {
+				const identifier = (entry as Record<string, unknown>)['dct:identifier'];
+				entries.push({'dcat:catalog': catalog, 'dct:identifier': typeof identifier === 'string' ? identifier : ''});
+			}
+		}
+	}
+	return entries;
+}

--- a/src/app/modify/modify.component.ts
+++ b/src/app/modify/modify.component.ts
@@ -43,6 +43,7 @@ import {ValidationGroup} from './components/validation-alert/validation-alert.co
 import {environment} from '../../environments/environment';
 import {MatIconModule} from '@angular/material/icon';
 import {FormCacheService} from '../services/form-cache.service';
+import {normalizeExternalCatalogs} from './external-catalogs.util';
 import {FormFieldTooltipComponent} from './form/components/form-field-tooltip/form-field-tooltip.component';
 import {FieldDebugOverlayComponent, FieldValidationDebugInfo} from './form/components/field-debug-overlay/field-debug-overlay.component';
 
@@ -386,6 +387,8 @@ export class ModifyComponent implements OnInit, OnDestroy {
 					// This preserves user's unsaved changes when navigating back from submit
 					if (cachedData && !this.showSubmitSection) {
 						this.datasetForm.patchValue(cachedData);
+						// patchValue skips FormArrays; rebuild them from the cached value (#260).
+						this.populateExternalCatalogs(cachedData['bv:externalCatalogs']);
 						// Store the original dataset for reset functionality
 						this.originalDataset = {...dataset};
 					} else {
@@ -398,6 +401,7 @@ export class ModifyComponent implements OnInit, OnDestroy {
 			// For new datasets, check if there's cached data
 			if (cachedData && !this.showSubmitSection) {
 				this.datasetForm.patchValue(cachedData);
+				this.populateExternalCatalogs(cachedData['bv:externalCatalogs']);
 			}
 		}
 	}
@@ -417,6 +421,10 @@ export class ModifyComponent implements OnInit, OnDestroy {
 		});
 
 		this.datasetForm.patchValue(patchData);
+
+		// FormArrays are not filled by patchValue (it only writes into controls that already exist),
+		// so they must be rebuilt explicitly from the record (#260).
+		this.populateExternalCatalogs(dataset['bv:externalCatalogs']);
 	}
 
 	onCancel(): void {
@@ -585,22 +593,63 @@ export class ModifyComponent implements OnInit, OnDestroy {
 
 	onExternalCatalogChange(catalogValue: string, isChecked: boolean): void {
 		const formArray = this.externalCatalogsArray;
+		const index = this.externalCatalogIndex(catalogValue);
 
 		if (isChecked) {
-			// Add the catalog to the array if it's not already there
-			if (!formArray.value.includes(catalogValue)) {
-				formArray.push(new FormControl(catalogValue));
+			if (index < 0) {
+				formArray.push(this.createExternalCatalogGroup(catalogValue));
 			}
-		} else {
-			// Remove the catalog from the array
-			const index = formArray.value.indexOf(catalogValue);
-			if (index >= 0) {
-				formArray.removeAt(index);
-			}
+		} else if (index >= 0) {
+			formArray.removeAt(index);
 		}
 
 		// Handle validation schema changes
 		this.handleValidationSchemaChanges(catalogValue, isChecked);
+	}
+
+	/**
+	 * One entry of `bv:externalCatalogs`. The schema declares an array of objects
+	 * (`dcat:catalog` required, `additionalProperties: false`), not an array of strings (issue #260).
+	 *
+	 * `dct:identifier` is the ID assigned by the external catalog at first publication. It is not
+	 * user-editable, but it MUST survive an edit round-trip — re-checking a box has to keep the
+	 * existing ID rather than silently clearing the record's link to the published dataset.
+	 */
+	private createExternalCatalogGroup(catalogValue: string, identifier = ''): FormGroup {
+		return this.fb.group({
+			'dcat:catalog': [catalogValue],
+			'dct:identifier': [identifier]
+		});
+	}
+
+	private externalCatalogIndex(catalogValue: string): number {
+		return this.externalCatalogsArray.controls.findIndex(control => control.get('dcat:catalog')?.value === catalogValue);
+	}
+
+	/**
+	 * Rebuild the `bv:externalCatalogs` FormArray from a loaded record.
+	 *
+	 * Necessary because FormArray.patchValue only writes into controls that already exist, and the
+	 * array is created empty — so a loaded record's catalogs were never restored, the checkboxes
+	 * rendered unchecked, and saving dropped the field entirely (taking the external catalogs'
+	 * dct:identifier with it). Legacy string entries (written by the pre-fix form) are normalised.
+	 */
+	private populateExternalCatalogs(value: unknown): void {
+		const formArray = this.externalCatalogsArray;
+		if (!formArray) {
+			return;
+		}
+		formArray.clear();
+
+		const entries = normalizeExternalCatalogs(value);
+		for (const entry of entries) {
+			formArray.push(this.createExternalCatalogGroup(entry['dcat:catalog'], entry['dct:identifier']));
+		}
+
+		// Re-arm the advisory i14y / ods validation for the catalogs the record already declares.
+		for (const entry of entries) {
+			this.handleValidationSchemaChanges(entry['dcat:catalog'], true);
+		}
 	}
 
 	private handleValidationSchemaChanges(catalogValue: string, isChecked: boolean): void {
@@ -822,7 +871,7 @@ export class ModifyComponent implements OnInit, OnDestroy {
 	}
 
 	isExternalCatalogSelected(catalogValue: string): boolean {
-		return this.externalCatalogsArray.value.includes(catalogValue);
+		return this.externalCatalogIndex(catalogValue) >= 0;
 	}
 
 	private collectInvalidFields(): void {

--- a/src/app/services/dataset-json.service.spec.ts
+++ b/src/app/services/dataset-json.service.spec.ts
@@ -45,4 +45,58 @@ describe('DatasetJsonService', () => {
 		expect(json.hasOwnProperty('dcatap:availability')).toBe(false);
 		expect(json.hasOwnProperty('dct:issued')).toBe(false);
 	});
+
+	// Issue #260 class: these fields are `array` of `string` in the schema, but the edit form binds
+	// each to a single text input, so typing in one turns the value into a bare string.
+	describe('array-of-string fields keep the schema shape (#260)', () => {
+		it.each(['prov:wasDerivedFrom', 'prov:wasGeneratedBy', 'dcat:inSeries', 'dct:replaces'])(
+			'wraps a typed scalar for %s into an array',
+			field => {
+				const json = service.generateDatasetJson({'dct:identifier': 'test-id', [field]: 'AGIS'} as any);
+				expect((json as any)[field]).toEqual(['AGIS']);
+			}
+		);
+
+		it('splits the comma-separated text Angular renders for a multi-valued array', () => {
+			// A text input bound to ['a','b','c'] displays "a,b,c"; editing it yields that string back.
+			const json = service.generateDatasetJson({'dct:identifier': 'test-id', 'prov:wasDerivedFrom': 'AGIS, GELAN ,ISVET'});
+			expect(json['prov:wasDerivedFrom']).toEqual(['AGIS', 'GELAN', 'ISVET']);
+		});
+
+		it('leaves an untouched array alone', () => {
+			const json = service.generateDatasetJson({'dct:identifier': 'test-id', 'prov:wasDerivedFrom': ['AGIS', 'GELAN']});
+			expect(json['prov:wasDerivedFrom']).toEqual(['AGIS', 'GELAN']);
+		});
+
+		it('drops the field when the text is blank', () => {
+			const json = service.generateDatasetJson({'dct:identifier': 'test-id', 'dcat:inSeries': '  '});
+			expect(json.hasOwnProperty('dcat:inSeries')).toBe(false);
+		});
+
+		it('does not mutate the caller\'s form value', () => {
+			const formValue: any = {'dct:identifier': 'test-id', 'prov:wasGeneratedBy': 'Datenportal'};
+			service.generateDatasetJson(formValue);
+			expect(formValue['prov:wasGeneratedBy']).toBe('Datenportal');
+		});
+	});
+
+	describe('bv:externalCatalogs is written as objects (#260)', () => {
+		it('preserves the object shape and the externally-assigned dct:identifier', () => {
+			const json = service.generateDatasetJson({
+				'dct:identifier': 'test-id',
+				'bv:externalCatalogs': [{'dcat:catalog': 'I14Y', 'dct:identifier': 'admin-dataset-12345'}]
+			});
+
+			expect(json['bv:externalCatalogs']).toEqual([{'dcat:catalog': 'I14Y', 'dct:identifier': 'admin-dataset-12345'}]);
+		});
+
+		it('drops a blank dct:identifier rather than emitting it (additionalProperties is false, the key is optional)', () => {
+			const json = service.generateDatasetJson({
+				'dct:identifier': 'test-id',
+				'bv:externalCatalogs': [{'dcat:catalog': 'I14Y', 'dct:identifier': ''}]
+			});
+
+			expect(json['bv:externalCatalogs']).toEqual([{'dcat:catalog': 'I14Y'}]);
+		});
+	});
 });

--- a/src/app/services/dataset-json.service.ts
+++ b/src/app/services/dataset-json.service.ts
@@ -6,6 +6,17 @@ import {DatasetSchema} from '../models/schemas/dataset';
 })
 export class DatasetJsonService {
 	/**
+	 * Fields the schema declares as `array` of `string`, but which the edit form binds to a single
+	 * text input. An untouched control still holds the record's array, yet as soon as the user types
+	 * the control value becomes a bare string — and that scalar was written straight to the record,
+	 * violating the schema (issue #260 class; `prov:wasGeneratedBy: "Datenportal"` is a live example).
+	 *
+	 * Angular renders an array in a text input as `a,b,c`, so splitting on commas round-trips exactly
+	 * what the user was shown and keeps multi-valued records (prov:wasDerivedFrom holds up to 5) intact.
+	 */
+	private static readonly ARRAY_OF_STRING_FIELDS = ['prov:wasDerivedFrom', 'prov:wasGeneratedBy', 'dcat:inSeries', 'dct:replaces'];
+
+	/**
 	 * Generate dataset JSON from form data
 	 */
 	generateDatasetJson(formData: any): DatasetSchema {
@@ -23,11 +34,28 @@ export class DatasetJsonService {
 			});
 		}
 
+		// Restore the schema's array shape for fields the form edits as free text.
+		const shaped = this.coerceArrayOfStringFields(formData);
+
 		// Clean up empty values
-		const cleanedData = this.removeEmptyValues(formData);
+		const cleanedData = this.removeEmptyValues(shaped);
 
 		// Reorder to put identifier first
 		return this.reorderIdentifierFirst(cleanedData);
+	}
+
+	private coerceArrayOfStringFields(formData: any): any {
+		const shaped = {...formData};
+		for (const key of DatasetJsonService.ARRAY_OF_STRING_FIELDS) {
+			const value = shaped[key];
+			if (typeof value === 'string') {
+				shaped[key] = value
+					.split(',')
+					.map(entry => entry.trim())
+					.filter(entry => entry !== '');
+			}
+		}
+		return shaped;
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The schema declares `bv:externalCatalogs` as an **array of objects** (`dcat:catalog` required, optional `dct:identifier`, `additionalProperties: false`). The form wrote an **array of bare strings**, so committed records violate the schema and render as blank rows in the detail page's *Publications* table.

Verified against live data — `824e4bde-af7e-4fa3-97d6-7a4f1cfc776f` is already corrupted:

```json
"bv:externalCatalogs": ["I14Y", "opendata.swiss"]
```

Nothing catches it: validation is per-field (required/pattern) only, so `items.type: object` is never enforced.

## Two bugs, one field

**1. Wrong shape on write.** `onExternalCatalogChange` pushed `new FormControl(catalogValue)`. The `FormArray` now holds `{dcat:catalog, dct:identifier}` groups; selection and removal match on `dcat:catalog`.

**2. Silent data loss on edit.** The `FormArray` was created empty and `populateForm` only calls `patchValue` — which writes into controls that *already exist*. So a loaded record's catalogs were never restored:

```
patchValue([{dcat:catalog:'I14Y', dct:identifier:'admin-12345'}])  ->  length: 0, value: []
generateDatasetJson({'bv:externalCatalogs': []})                   ->  field dropped entirely
```

Opening any record in the edit form and saving it **stripped its external catalogs**, including the `dct:identifier` the external catalog assigned at first publication (the record's link to the published dataset). The checkboxes also always rendered unchecked. The array is now rebuilt explicitly from the record — and from cached unsaved edits — preserving that id, and the advisory i14y/ods validation is re-armed for the catalogs the record already declares.

Loading tolerates the legacy string shape, and the detail page renders it instead of a blank row, so the already-corrupted record stays readable.

## Same bug class, found while auditing

I swept the schema for array fields bound to plain text inputs. Four are `array` of `string` but bound to a single `<input>`:

`prov:wasDerivedFrom`, `prov:wasGeneratedBy`, `dcat:inSeries`, `dct:replaces`

An untouched control keeps the record's array, but once the user types, the value becomes a bare string written straight to the record. **Live corruption already exists**: `prov:wasGeneratedBy: "Datenportal"` and two scalar `dcat:inSeries` values. `generateDatasetJson` now coerces these back to arrays. Angular renders an array in a text input as `a,b,c`, so splitting on commas round-trips exactly what the user sees and keeps multi-valued records intact (`prov:wasDerivedFrom` holds up to 5 entries).

### Audited and NOT affected
- `dcat:theme`, `dcat:keyword` — multi-select CVAs; arrays in all 81/77 upstream records
- `dcat:distribution`, `prov:qualifiedAttribution` — CVAs writing object arrays
- `foaf:page` — object array, not editable in the form
- `schema-to-formly.service.ts` also assumes the string shape, but is **dead code** (imported nowhere)

## Notes

- Extracts `normalizeExternalCatalogs()` as a pure helper so the shape rules are unit-testable without standing up a `ModifyComponent` TestBed (develop has no such harness).
- **Data migration is out of scope**: the three already-corrupted upstream records (`bv:externalCatalogs` string array, `prov:wasGeneratedBy` scalar, `dcat:inSeries` scalars) still need fixing in the metadata repo. This PR stops new corruption and reads the old shape without breaking.
- Touches `modify.component.ts`, which `feat/221` rewrites heavily — expect a merge conflict there.

## Tests
37 pass (+23). Covers both shapes, mixed arrays, `dct:identifier` preservation and blank-id dropping, scalar→array coercion for all four fields, comma splitting, untouched arrays, and non-mutation of the caller's form value.

Refs #260. (Issue stays open for testing — do not auto-close.)

