### PR TITLE
fix(#222): remove non-prefixed duplicate tooltip keys

### DIFF
--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -148,8 +148,6 @@
   },
   "tooltips": {
     "adms:status": "Status des Datenprodukts: Befindet es sich in Bearbeitung, ist es fertiggestellt usw.",
-    "applicableLegislation": "Diese Eigenschaft bezieht sich auf die Rechtsgrundlage des Datenprodukts",
-    "archivalValue": "Hat das Datenprodukt aufgrund der darin enthaltenen administrativen, rechtlichen, steuerlichen, beweiskräftigen oder historischen Informationen eine anhaltende Nützlichkeit oder Bedeutung, die seine weitere Aufbewahrung rechtfertigt?",
     "bv:abrogation": "Was ist das Aufhebungdatum?",
     "bv:archivalValue": "Hat das Datenprodukt aufgrund der darin enthaltenen administrativen, rechtlichen, steuerlichen, beweiskräftigen oder historischen Informationen einen anhaltenden Nutzen oder eine anhaltende Bedeutung, die seine weitere Aufbewahrung rechtfertigen?",
     "bv:classification": "Was ist die Klassifizierung der Datensammlung gemäss Informationssicherheitsgesetz (siehe Art. 13 ISG)?",
@@ -189,16 +187,7 @@
     "prov:qualifiedAttribution": "Wer hat welche Rolle für dieses Datenprodukt?",
     "prov:wasDerivedFrom": "Von welchem anderen Datenprodukt wurde dieses Datenprodukt abgeleitet?",
     "prov:wasGeneratedBy": "Durch welchen Geschäftsprozess wurde dieses Datenprodukt generiert?",
-    "qualifiedAttribution": "Wer hat welche Rolle für dieses Datenprodukt?",
-    "replaces": "Welches Datenprodukt wird ersetzt?",
-    "schema:comment": "Gibt es weitere relevante Informationen zu diesem Datenprodukt?",
-    "spatial": "Welcher geografische Bereich wird von dem Datenprodukt abgedeckt?",
-    "status": "Status des Datenprodukts: Befindet es sich in Arbeit, ist es fertiggestellt, veröffentlicht, oder archiviert?",
-    "temporal": "Welcher Zeitraum wird von Ihrem Datenprodukt abgedeckt?",
-    "theme": "Thema, das zur Klassifizierung der Datenprodukte des Katalogs verwendet wird",
-    "title": "Titel Ihres Datenprodukts",
-    "typeOfData": "Welcher Typ beschreibt Ihr Datenprodukt am besten?",
-    "version": "Um welche Version handelt es sich? Bitte verwenden Sie semantische Versionsnummern in der Form X.Y.Z, wobei eine Erhöhung von X auf größere Änderungen, Y auf kleinere Änderungen und Z auf einfache Korrekturen wie Tippfehler hinweist."
+    "schema:comment": "Gibt es weitere relevante Informationen zu diesem Datenprodukt?"
   },
   "labels": {
     "dcat:endpointURL": "Endpunkt-URL",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -148,8 +148,6 @@
   },
   "tooltips": {
     "adms:status": "Status of the data product: Is it work in progress, finished etc.",
-    "applicableLegislation": "This property refers to the legal basis of the data product.",
-    "archivalValue": "Does the data product have ongoing usefulness or significance, based on the administrative, legal, fiscal, evidential, or historical information they contain, which justifies their continued preservation.",
     "bv:abrogation": "What is the abrogation date?",
     "bv:archivalValue": "Does the data product have ongoing usefulness or significance, based on the administrative, legal, fiscal, evidential, or historical information they contain, which justifies their continued preservation.",
     "bv:classification": "What is the classification of data set according to the Information Security Act (see Art. 13 ISA)?",
@@ -189,16 +187,7 @@
     "prov:qualifiedAttribution": "Who has which role for this data product?",
     "prov:wasDerivedFrom": "What other data product whas this data product derived from?",
     "prov:wasGeneratedBy": "What business process has generated this data product?",
-    "qualitifedAttribution": "Who has which role for this data product?",
-    "replaces": "Which  data product is replaced?",
-    "schema:comment": "Is the other relevant information to this data product?",
-    "spatial": "What geographic region is covered by the data product?",
-    "status": "Status of the data product: Is it work in progress, finished etc.",
-    "temporal": "What time period is covered in your data product",
-    "theme": "Theme used to classify the catalogue's data products.",
-    "title": "Title of your data product",
-    "typeOfData": "What type best describes your data product?",
-    "version": "What version is this? Please use semantic versioning in the form of X.Y.Z where increases of X indicate major changes, Y minor changes and Z simple corrections such as typos."
+    "schema:comment": "Is the other relevant information to this data product?"
     },
   "labels": {
     "dcat:endpointURL": "Endpoint URL",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -148,8 +148,6 @@
   },
   "tooltips": {
     "adms:status": "Statut du produit de données : en cours de traitement, terminé, etc.",
-    "applicableLegislation": "Cette propriété se rapporte à la base juridique du produit de données.",
-    "archivalValue": "Le produit de données a-t-il une utilité ou une importance durable qui justifie sa conservation en raison des informations administratives, juridiques, fiscales, probantes ou historiques qu'il contient ?",
     "bv:abrogation": "Quelle est la date d'abrogation ?",
     "bv:archivalValue": "Le produit de données présente-t-il, en raison des informations administratives, juridiques, fiscales, probantes ou historiques qu'il contient, une utilité ou une importance durable qui justifie sa conservation ?",
     "bv:classification": "Quelle est la classification de la collecte de données selon la loi sur la sécurité de l'information (voir art. 13 LSI) ?",
@@ -189,16 +187,7 @@
     "prov:qualifiedAttribution": "Qui joue quel rôle dans ce produit de données ?",
     "prov:wasDerivedFrom": "De quel autre produit de données ce produit de données est-il dérivé ?",
     "prov:wasGeneratedBy": "Par quel processus métier ce produit de données a-t-il été généré ?",
-    "qualifiedAttribution": "Qui joue quel rôle dans ce produit de données ?",
-    "replaces": "Quel produit de données est remplacé ?",
-    "schema:comment": "Votre produit de données est-il conforme à certaines normes et/ou spécifications ?",
-    "spatial": "Quelle zone géographique couvre le produit de données ?",
-    "status": "Statut du produit de données : en cours de traitement, terminé, etc.",
-    "temporal": "Quelle période votre produit de données couvre-t-il ?",
-    "theme": "Thème utilisé pour classer les produits de données dans le catalogue.",
-    "title": "Titre de votre produit de données",
-    "typeOfData": "Quel type décrit le mieux votre produit de données ?",
-    "version": "De quelle version s'agit-il ? Veuillez utiliser des numéros de version sémantiques sous la forme X.Y.Z, où une augmentation de X indique des modifications importantes, Y des modifications mineures et Z des corrections simples telles que des fautes de frappe."
+    "schema:comment": "Votre produit de données est-il conforme à certaines normes et/ou spécifications ?"
 },
   "labels": {
     "dcat:endpointURL": "URL du point d'accès",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -148,8 +148,6 @@
   },
   "tooltips": {
     "adms:status": "Stato del prodotto dati: se è in fase di elaborazione, se è completato, ecc.",
-    "applicableLegislation": "Questa caratteristica si riferisce alla base giuridica del prodotto di dati.",
-    "archivalValue": "Il prodotto di dati ha un'utilità o un'importanza duratura che ne giustifica l'ulteriore conservazione a causa delle informazioni amministrative, legali, fiscali, probatorie o storiche in esso contenute?",
     "bv:abrogation": "Qual è la data di abrogazione?",
     "bv:archivalValue": "Il prodotto di dati ha un'utilità o un significato duraturo che ne giustifica l'ulteriore conservazione a causa delle informazioni amministrative, legali, fiscali, probatorie o storiche in esso contenute?",
     "bv:classification": "Qual è la classificazione della collezione di dati secondo la legge sulla sicurezza delle informazioni (cfr. art. 13 LSIn)?",


### PR DESCRIPTION
## Problem
The `tooltips` block carried two variants of the same entry — a prefixed one
(`dct:title`) and a non-prefixed one (`title`).

Only the prefixed keys are reachable. Every tooltip lookup is built dynamically as
`` `tooltips.${field}` `` — in `details.component.ts`, `form-field-tooltip.component.ts` and
`field-debug-overlay.component.ts` — and the field is always a schema property name, which
carries its vocabulary prefix. The non-prefixed entries were dead copies, and they had
drifted from the live text over time.

## Change
Removes the non-prefixed duplicates: **11** from `de`/`en`/`fr`, **2** from `it`. All four
languages now sit at a consistent **41** tooltips (they were 52/52/52/43).

`en` additionally carried the key misspelled as `qualitifedAttribution`.

`labels.image` is non-prefixed but has **no** prefixed counterpart — it is a genuine UI
label, not a duplicate, and is kept.

## Verification
- No schema property name collides with any removed key (checked against the runtime
  `dataset.json` from the metadata repo; its only non-prefixed properties are `alias`,
  `uri` and the language codes).
- 723/723 jest, 43/43 playwright, AOT build clean.
- Only the `tooltips` block changed; every surviving value is byte-identical (asserted
  during the edit).

## For review: the dead copies had drifted
Deleting them loses nothing that was ever displayed, but the wording differences show
where the two copies diverged. All are stylistic restatements of the same meaning except
the last, where the **dead** copy was arguably more informative than the live one:

| key | live text (kept) | dead text (removed) |
|---|---|---|
| `de` `dct:spatial` | Welchen geografischen Bereich deckt das Datenprodukt ab? | Welcher geografische Bereich wird von dem Datenprodukt abgedeckt? |
| `de` `bv:archivalValue` | …einen anhaltenden Nutzen oder eine anhaltende Bedeutung… | …eine anhaltende Nützlichkeit oder Bedeutung… |
| `fr` `bv:archivalValue` | Le produit de données présente-t-il, en raison des informations…, une utilité… | Le produit de données a-t-il une utilité… en raison des informations… |
| `it` `bv:archivalValue` | …un'utilità o un **significato** duraturo… | …un'utilità o un'**importanza** duratura… |
| **`de` `adms:status`** | Status des Datenprodukts: Befindet es sich in Bearbeitung, ist es fertiggestellt **usw.** | Status des Datenprodukts: Befindet es sich in Arbeit, ist es fertiggestellt, **veröffentlicht, oder archiviert**? |

@hurni — worth a look at `de` `adms:status`: the live tooltip trails off with "usw.", while the
copy being deleted enumerated the actual states. If you prefer the fuller wording, say so and
I'll port it onto the prefixed key as a separate change rather than smuggle a text edit into a
de-duplication PR.

Refs #222. (Issue stays open for testing — do not auto-close.)
