### PR TITLE
fix(#284): stop an edit deleting fields the schema no longer declares

### DIFF
--- a/src/app/modify/modify.component.html
+++ b/src/app/modify/modify.component.html
@@ -434,7 +434,13 @@
 
 		<!-- Submit Section -->
 		<div *ngIf="showSubmitSection">
-			<app-dataset-submit [formData]="datasetForm.value" [isEditMode]="isEditMode" [datasetId]="datasetId" [productType]="productType || 'dataset'">
+			<app-dataset-submit
+				[formData]="datasetForm.value"
+				[baseRecord]="preservedBaseRecord"
+				[isEditMode]="isEditMode"
+				[datasetId]="datasetId"
+				[productType]="productType || 'dataset'"
+			>
 			</app-dataset-submit>
 
 			<div class="ob-mt-3">

--- a/src/app/modify/modify.component.spec.ts
+++ b/src/app/modify/modify.component.spec.ts
@@ -718,4 +718,47 @@ describe('ModifyComponent', () => {
 			expect(component.odsValidationErrors).toEqual([]);
 		});
 	});
+
+	describe('preservedBaseRecord (#284)', () => {
+		// What the submit step merges its form output over, so an edit cannot delete record fields
+		// the schema no longer declares and the form therefore never rendered.
+		const base = (c: any) => c['preservedBaseRecord'] as Record<string, unknown>;
+		const record = {'dct:identifier': 'id-1', 'bv:itSystem': 'https://agis.admin.ch'};
+
+		it('exposes the loaded record when editing it as the type it was loaded as', () => {
+			Object.assign(component as any, {
+				isEditMode: true,
+				productType: 'dataset',
+				originalDataset: record,
+				originalProductType: 'dataset'
+			});
+
+			expect(base(component)).toEqual(record);
+		});
+
+		it('is empty when creating, so a new record inherits nothing', () => {
+			Object.assign(component as any, {isEditMode: false, originalDataset: record, originalProductType: 'dataset'});
+
+			expect(base(component)).toEqual({});
+		});
+
+		it('is empty when no record was loaded', () => {
+			Object.assign(component as any, {isEditMode: true, originalDataset: null});
+
+			expect(base(component)).toEqual({});
+		});
+
+		it('is empty once the product type differs from the one the record was loaded as', () => {
+			// Not reachable today (the type selector is create-mode only), but grafting a dataset's
+			// fields onto a dataService would corrupt rather than protect.
+			Object.assign(component as any, {
+				isEditMode: true,
+				productType: 'dataService',
+				originalDataset: record,
+				originalProductType: 'dataset'
+			});
+
+			expect(base(component)).toEqual({});
+		});
+	});
 });

--- a/src/app/modify/modify.component.ts
+++ b/src/app/modify/modify.component.ts
@@ -90,8 +90,14 @@ export class ModifyComponent implements OnInit, OnDestroy {
 	schemaLoadError: string | null = null;
 	schemasLoading = true;
 
-	// Store original dataset for reset functionality in edit mode
+	// Store original dataset for reset functionality in edit mode, and as the base the submit step
+	// merges over so fields the schema no longer declares survive an edit (#284).
 	private originalDataset: any = null;
+
+	// The product type originalDataset was loaded as. The type selector is create-mode only, so this
+	// cannot drift today; it is kept so that making the type editable later cannot silently graft
+	// one type's fields onto another record.
+	private originalProductType: DataProductType | null = null;
 
 	// The data that must currently be present in the form (a loaded record, or cached unsaved edits).
 	// buildFormFromMetadata tears down and recreates every control whenever the product type's schema
@@ -469,6 +475,7 @@ export class ModifyComponent implements OnInit, OnDestroy {
 						this.patchIntoForm(cachedData);
 						// Store the original dataset for reset functionality
 						this.originalDataset = {...dataset};
+						this.originalProductType = this.productType;
 					} else {
 						this.populateForm(dataset);
 					}
@@ -489,7 +496,26 @@ export class ModifyComponent implements OnInit, OnDestroy {
 	private populateForm(dataset: any): void {
 		// Store original dataset for reset functionality
 		this.originalDataset = {...dataset};
+		this.originalProductType = this.productType;
 		this.patchIntoForm(dataset);
+	}
+
+	/**
+	 * The record the submit step merges its form output over, so an edit cannot delete fields the
+	 * schema no longer declares and the form therefore never rendered (#284).
+	 *
+	 * Empty unless we are editing that same record as the same product type — a new record has
+	 * nothing to preserve, and grafting one type's fields onto another would corrupt rather than
+	 * protect.
+	 */
+	protected get preservedBaseRecord(): Record<string, unknown> {
+		if (!this.isEditMode || !this.originalDataset) {
+			return {};
+		}
+		if (this.originalProductType && this.productType !== this.originalProductType) {
+			return {};
+		}
+		return this.originalDataset;
 	}
 
 	/**

--- a/src/app/modify/submit/dataset-submit.component.spec.ts
+++ b/src/app/modify/submit/dataset-submit.component.spec.ts
@@ -87,7 +87,7 @@ describe('DatasetSubmitComponent', () => {
 		expect(component.selectedRepository).toBe('blw-ofag-ufag/metadata');
 		expect(component.isAuthenticated).toBe(true);
 		expect(component.selectedPublisher).toEqual(publisher);
-		expect(datasetJson.generateDatasetJson).toHaveBeenCalledWith({title: 'x'});
+		expect(datasetJson.generateDatasetJson).toHaveBeenCalledWith({title: 'x'}, {});
 		expect(component.generatedJson).toBe(generatedJson);
 		expect(component.formattedJson).toBe('{"dct:identifier":"my-dataset"}');
 		expect(component.filePath).toBe('datasets/my-dataset.json');
@@ -98,6 +98,13 @@ describe('DatasetSubmitComponent', () => {
 		fixture.detectChanges();
 		expect(datasetJson.generateDatasetJson).not.toHaveBeenCalled();
 		expect(component.generatedJson).toBeNull();
+	});
+
+	it('passes the loaded record through as the merge base, so an edit cannot drop unknown fields (#284)', async () => {
+		await setup({formData: {title: 'x'}, baseRecord: {'bv:itSystem': 'https://agis.admin.ch'}});
+		fixture.detectChanges();
+
+		expect(datasetJson.generateDatasetJson).toHaveBeenCalledWith({title: 'x'}, {'bv:itSystem': 'https://agis.admin.ch'});
 	});
 
 	describe('commitDirectlyToGitHub', () => {

--- a/src/app/modify/submit/dataset-submit.component.ts
+++ b/src/app/modify/submit/dataset-submit.component.ts
@@ -32,6 +32,12 @@ import {DEFAULT_DATA_PRODUCT_TYPE, DataProductType} from '../../models/data-prod
 export class DatasetSubmitComponent implements OnInit, OnDestroy {
 	// Inputs
 	@Input() formData: Record<string, unknown> = {};
+	/**
+	 * The record the form was loaded from. Merged under `formData` when generating the JSON so that
+	 * fields the current schema no longer declares — and which therefore have no form control —
+	 * survive an edit instead of being silently deleted (#284). Empty when creating.
+	 */
+	@Input() baseRecord: Record<string, unknown> = {};
 	@Input() isEditMode = false;
 	@Input() datasetId?: string | null;
 	@Input() productType: DataProductType = DEFAULT_DATA_PRODUCT_TYPE;
@@ -260,8 +266,9 @@ export class DatasetSubmitComponent implements OnInit, OnDestroy {
 			return;
 		}
 
-		// Generate dataset JSON
-		this.generatedJson = this.datasetJsonService.generateDatasetJson(this.formData);
+		// Generate dataset JSON, preserving any fields the loaded record carries but the schema-driven
+		// form has no control for (#284).
+		this.generatedJson = this.datasetJsonService.generateDatasetJson(this.formData, this.baseRecord);
 
 		// Format for display
 		this.formattedJson = this.datasetJsonService.formatJsonForDisplay(this.generatedJson);

--- a/src/app/services/dataset-json.service.spec.ts
+++ b/src/app/services/dataset-json.service.spec.ts
@@ -191,4 +191,49 @@ describe('DatasetJsonService', () => {
 			expect(json['bv:externalCatalogs']).toEqual([{'dcat:catalog': 'I14Y'}]);
 		});
 	});
+
+	describe('fields the schema no longer declares survive an edit (#284)', () => {
+		// The form builds its controls from the runtime schema, so a record field the schema dropped
+		// gets no control and never reaches formData. bv:itSystem is the live case: removed from the
+		// schema, still present on 23 published records.
+		it('keeps a base-record field that the form has no control for', () => {
+			const json: any = service.generateDatasetJson(
+				{'dct:identifier': 'test-id', 'dct:title': {de: 'Titel'}},
+				{'dct:identifier': 'test-id', 'bv:itSystem': 'https://agis.admin.ch', 'dct:title': {de: 'alt'}}
+			);
+
+			expect(json['bv:itSystem']).toBe('https://agis.admin.ch');
+		});
+
+		it('lets the form win over the base for every field the form does control', () => {
+			const json: any = service.generateDatasetJson(
+				{'dct:identifier': 'test-id', 'dct:title': {de: 'neu'}},
+				{'dct:identifier': 'test-id', 'dct:title': {de: 'alt'}}
+			);
+
+			expect(json['dct:title']).toEqual({de: 'neu'});
+		});
+
+		it('still clears a field the user emptied, rather than resurrecting it from the base', () => {
+			const json: any = service.generateDatasetJson({'dct:identifier': 'test-id', 'dcat:version': ''}, {'dct:identifier': 'test-id', 'dcat:version': '1.0.0'});
+
+			expect(json['dcat:version']).toBeUndefined();
+		});
+
+		it('defaults to no base, so creating a record cannot inherit anything', () => {
+			const json: any = service.generateDatasetJson({'dct:identifier': 'test-id', 'dct:title': {de: 'x'}});
+
+			expect(Object.keys(json)).toEqual(['dct:identifier', 'dct:title']);
+		});
+
+		it('does not mutate either argument', () => {
+			const formData = {'dct:identifier': 'test-id', 'dcat:distribution': [{'dct:title': {de: 'd'}}]};
+			const base = {'dct:identifier': 'test-id', 'bv:itSystem': 'x'};
+
+			service.generateDatasetJson(formData, base);
+
+			expect(formData).toEqual({'dct:identifier': 'test-id', 'dcat:distribution': [{'dct:title': {de: 'd'}}]});
+			expect(base).toEqual({'dct:identifier': 'test-id', 'bv:itSystem': 'x'});
+		});
+	});
 });

--- a/src/app/services/dataset-json.service.ts
+++ b/src/app/services/dataset-json.service.ts
@@ -18,25 +18,36 @@ export class DatasetJsonService {
 	private static readonly ARRAY_OF_STRING_FIELDS = ['prov:wasDerivedFrom', 'prov:wasGeneratedBy', 'dcat:inSeries', 'dct:replaces'];
 
 	/**
-	 * Generate dataset JSON from form data
+	 * Generate dataset JSON from form data.
+	 *
+	 * `baseRecord` is the record the form was loaded from, and exists to stop an edit destroying
+	 * data the form cannot show (issue #284). The form's controls are rebuilt from the runtime
+	 * schema, so a record field the schema no longer declares gets no control, never reaches
+	 * `formData`, and would otherwise vanish on save — `bv:itSystem` is still on 23 published
+	 * records after being dropped from the schema.
+	 *
+	 * Form values always win: every schema-declared field is present in `formData`, so a field the
+	 * user cleared arrives empty, overrides the base, and is then dropped by `removeEmptyValues`.
+	 * Only keys absent from `formData` survive from the base.
 	 */
-	generateDatasetJson(formData: any): DatasetSchema {
+	generateDatasetJson(formData: any, baseRecord: Record<string, unknown> = {}): DatasetSchema {
+		// Merge first, and work on the copy: the caller's form value must not be mutated.
+		const merged: any = {...baseRecord, ...formData};
+
 		// Generate identifier if not provided
-		if (!formData['dct:identifier']) {
-			formData['dct:identifier'] = this.generateUUID();
+		if (!merged['dct:identifier']) {
+			merged['dct:identifier'] = this.generateUUID();
 		}
 
 		// Process distributions - ensure each has an identifier
-		if (formData['dcat:distribution'] && Array.isArray(formData['dcat:distribution'])) {
-			formData['dcat:distribution'].forEach((dist: any, index: number) => {
-				if (!dist['dct:identifier']) {
-					dist['dct:identifier'] = this.generateUUID();
-				}
-			});
+		if (merged['dcat:distribution'] && Array.isArray(merged['dcat:distribution'])) {
+			merged['dcat:distribution'] = merged['dcat:distribution'].map((dist: any) =>
+				dist && !dist['dct:identifier'] ? {...dist, 'dct:identifier': this.generateUUID()} : dist
+			);
 		}
 
 		// Restore the schema's array shape for fields the form edits as free text.
-		const shaped = this.coerceArrayOfStringFields(formData);
+		const shaped = this.coerceArrayOfStringFields(merged);
 
 		// Clean up empty values
 		const cleanedData = this.removeEmptyValues(shaped);


### PR DESCRIPTION
Fixes the data loss reported in #284.

## Problem

The edit form builds its controls from the **runtime-fetched schema**, and the submit step
serialised **pure form state**. So a record field the schema has since dropped gets no control,
never reaches `formData`, and is silently deleted on save.

`bv:itSystem` is the live case: removed from the schema in December (#225), still present on
**23 of 83 published records**, and destroyed by any edit to them.

This was never specific to those fields — *any* future schema removal would have quietly destroyed
that data on the next edit.

## Fix

`generateDatasetJson(formData, baseRecord)` now merges the form output **over** the record the form
was loaded from:

```ts
const merged = {...baseRecord, ...formData};
```

Form values still win for everything the schema declares. Every schema field is present in
`formData`, so a field the user cleared arrives empty, overrides the base, and is dropped by the
existing `removeEmptyValues`. **Only keys absent from `formData` survive from the base** — which is
exactly the set the form could not show.

As a side effect the method no longer mutates its caller's form value, which it previously did when
filling in missing identifiers.

## The guard

The base is threaded through `modify.component.html` via a new `preservedBaseRecord` getter that
returns `{}` unless we are editing **that same record** as **the same product type**.

The type selector is create-mode only (`@if (!isEditMode)`), so this cannot drift today. The guard
exists so that making the type editable later cannot graft a dataset's fields onto a dataService.

## Verification

- **733/733** jest (+10 specs), **43/43** playwright, AOT build clean.
- New specs pin the two behaviours that make this safe rather than merely additive:
  - a base field with no form control survives;
  - a field the user **cleared** still clears, rather than being resurrected from the base;
  - creating a record inherits nothing (base defaults to `{}`);
  - neither argument is mutated;
  - `preservedBaseRecord` is empty when creating, when nothing was loaded, and on type mismatch.

## Not addressed here

Whether those three orphaned fields should ultimately be **migrated out of the data** or **restored
to the schema** is a data decision for @hurni — see the open question on #284. This PR preserves
them; it does not take that decision.

Refs #284. (Issue stays open for testing — do not auto-close.)
