### PR TITLE
fix(#255): dcat:theme filter works and theme chips are clickable

### DIFF
--- a/src/app/details/metadata/free-list-item.component.html
+++ b/src/app/details/metadata/free-list-item.component.html
@@ -1,7 +1,9 @@
 <mat-chip-set>
 	@for (item of data; track $index) {
 		<mat-chip>
-			{{ getTranslatedValue(item) | translate }}
+			<a [routerLink]="['/index']" [queryParams]="queryParamsFor(item)">
+				{{ getTranslatedValue(item) | translate }}
+			</a>
 		</mat-chip>
 	}
 </mat-chip-set>

--- a/src/app/details/metadata/free-list-item.component.html
+++ b/src/app/details/metadata/free-list-item.component.html
@@ -1,7 +1,7 @@
 <mat-chip-set>
 	@for (item of data; track $index) {
 		<mat-chip>
-			<a [routerLink]="['/index']" [queryParams]="queryParamsFor(item)">
+			<a [routerLink]="['/index']" [queryParams]="queryParamsFor(item)" (mouseup)="navigateTo(item)" style="cursor: pointer">
 				{{ getTranslatedValue(item) | translate }}
 			</a>
 		</mat-chip>

--- a/src/app/details/metadata/metadata-item.component.spec.ts
+++ b/src/app/details/metadata/metadata-item.component.spec.ts
@@ -14,6 +14,7 @@ import {
 	DateMetadataItemComponent,
 	DefaultMetadataItemComponent,
 	EnumComponent,
+	FreeListItemComponent,
 	LinkComponent,
 	MetadataItemComponent,
 	NoComponent,
@@ -105,7 +106,7 @@ describe('MetadataItemComponent', () => {
 
 describe('DatasetLinkListComponent', () => {
 	it('builds /details query params, falling back to current publisher + default type when the ref is not in the store', () => {
-		const route: any = {snapshot: {queryParams: {publisher: 'PUB', lang: 'de', dataset: 'old'}}};
+		const route: {snapshot: {queryParams: Record<string, string>}} = {snapshot: {queryParams: {publisher: 'PUB', lang: 'de', dataset: 'old'}}};
 		TestBed.configureTestingModule({
 			imports: [DatasetLinkListComponent, provideTranslateTesting()],
 			providers: [
@@ -135,5 +136,54 @@ describe('EnumComponent', () => {
 		fixture.componentInstance.data = 'PUBLIC';
 		fixture.detectChanges();
 		expect(fixture.componentInstance.paramEntry['dct:accessRights']).toBe('PUBLIC');
+	});
+});
+
+describe('FreeListItemComponent', () => {
+	/**
+	 * #255: array-facet chips (dcat:theme, bv:dimensions) are rendered through NgComponentOutlet,
+	 * where a plain routerLink click does not navigate. They therefore need the same explicit
+	 * mouseup navigation the other outlet-rendered components use, or they look dead to the user
+	 * while the scalar enum chips next to them work.
+	 */
+	function setup(label: string, data: string[]) {
+		const navigate = jest.fn();
+		TestBed.configureTestingModule({
+			imports: [FreeListItemComponent, NoopAnimationsModule, provideTranslateTesting()],
+			providers: [
+				{provide: Router, useValue: {navigate, createUrlTree: jest.fn(() => ({})), serializeUrl: jest.fn(() => ''), events: of()}},
+				{provide: ActivatedRoute, useValue: {snapshot: {queryParams: {}}}},
+				{provide: 'label', useValue: label},
+				{provide: 'data', useValue: data}
+			]
+		});
+		const fixture = TestBed.createComponent(FreeListItemComponent);
+		return {fixture, navigate};
+	}
+
+	it('builds the index filter query params for a theme', () => {
+		const {fixture} = setup('dcat:theme', ['agriculture']);
+		expect(fixture.componentInstance.queryParamsFor('agriculture')).toEqual({'dcat:theme': 'agriculture'});
+	});
+
+	it('navigates to the filtered index on mouseup', () => {
+		const {fixture, navigate} = setup('dcat:theme', ['agriculture']);
+		fixture.componentInstance.navigateTo('agriculture');
+		expect(navigate).toHaveBeenCalledWith(['/index'], {queryParams: {'dcat:theme': 'agriculture'}});
+	});
+
+	it('does the same for the dimensions facet, which shares this component', () => {
+		const {fixture, navigate} = setup('bv:dimensions', ['time']);
+		fixture.componentInstance.navigateTo('time');
+		expect(navigate).toHaveBeenCalledWith(['/index'], {queryParams: {'bv:dimensions': 'time'}});
+	});
+
+	it('wires mouseup on the rendered anchor, not only on click', () => {
+		const {fixture, navigate} = setup('dcat:theme', ['agriculture']);
+		fixture.detectChanges();
+		const anchor = fixture.nativeElement.querySelector('mat-chip a') as HTMLElement;
+		expect(anchor).toBeTruthy();
+		anchor.dispatchEvent(new MouseEvent('mouseup', {bubbles: true}));
+		expect(navigate).toHaveBeenCalledWith(['/index'], {queryParams: {'dcat:theme': 'agriculture'}});
 	});
 });

--- a/src/app/details/metadata/metadata-item.component.ts
+++ b/src/app/details/metadata/metadata-item.component.ts
@@ -23,7 +23,7 @@ registerLocaleData(localeIt);
 @Component({
 	templateUrl: './free-list-item.component.html',
 	styleUrl: '../details.component.scss',
-	imports: [MatChip, MatChipSet, TranslatePipe],
+	imports: [MatChip, MatChipSet, TranslatePipe, RouterLink],
 	standalone: true
 })
 export class FreeListItemComponent {
@@ -37,6 +37,14 @@ export class FreeListItemComponent {
 		this.data = this.injector.get('data', []);
 		this.keywordService = this.injector.get(KeywordService);
 		this.translateService = this.injector.get(TranslateService);
+	}
+
+	/**
+	 * Query params that reproduce this chip as an index filter (#255).
+	 * Array facets filter with the same `field=value` URL shape as scalar enums.
+	 */
+	queryParamsFor(item: string): {[key: string]: string} {
+		return {[this.label]: item};
 	}
 
 	getTranslatedValue(item: string): string {

--- a/src/app/details/metadata/metadata-item.component.ts
+++ b/src/app/details/metadata/metadata-item.component.ts
@@ -31,12 +31,14 @@ export class FreeListItemComponent {
 	label: string = '';
 	private readonly keywordService: KeywordService;
 	private readonly translateService: TranslateService;
+	private readonly router: Router;
 
 	constructor(private readonly injector: Injector) {
 		this.label = this.injector.get('label', '');
 		this.data = this.injector.get('data', []);
 		this.keywordService = this.injector.get(KeywordService);
 		this.translateService = this.injector.get(TranslateService);
+		this.router = this.injector.get(Router);
 	}
 
 	/**
@@ -45,6 +47,16 @@ export class FreeListItemComponent {
 	 */
 	queryParamsFor(item: string): {[key: string]: string} {
 		return {[this.label]: item};
+	}
+
+	/**
+	 * Navigate on mouseup, like the other components rendered through NgComponentOutlet
+	 * (see DatasetLinkListComponent). Plain routerLink click navigation does not fire for
+	 * chips in this view, which is why the theme chip looked dead while the scalar enum
+	 * chips — rendered directly in details.component.html — worked (#255).
+	 */
+	navigateTo(item: string): void {
+		void this.router.navigate(['/index'], {queryParams: this.queryParamsFor(item)});
 	}
 
 	getTranslatedValue(item: string): string {

--- a/src/app/services/api/api.service.ts
+++ b/src/app/services/api/api.service.ts
@@ -152,8 +152,11 @@ export class DatasetService {
 								const datasetDimensions = this.getDimensionsArray(schema);
 								categoryMatches = choices.some(choice => datasetDimensions.includes(choice));
 							} else {
-								// For other categories, check if the schema value matches any of the choices
-								categoryMatches = choices.includes(schema[category] as string);
+								// For other categories, the stored value may be a scalar or an array
+								// (array facets such as `dcat:theme`, see #255). Treat both alike:
+								// a dataset matches when any of its values is among the choices.
+								const value = schema[category] as unknown;
+								categoryMatches = Array.isArray(value) ? value.some(v => choices.includes(v as string)) : choices.includes(value as string);
 							}
 
 							// If this category doesn't match, the dataset doesn't pass the filter


### PR DESCRIPTION
Closes #255.

Two defects behind the same report:

1. **Filter never matched.** `api.service` compared `schema[category]` directly against the selected choices. For array-valued facets (`dcat:theme`) that comparison is always false, so `?dcat:theme=agriculture` returned nothing. Arrays and scalars are now handled alike (any value in the array matching a choice counts).
2. **Chips were dead.** Array-enum chips on the detail page rendered as plain text, unlike scalar enum chips. They now link to `/index` with the corresponding query param, so clicking "Agriculture" lands on the filtered index.

`dcat:keyword` and `bv:dimensions` share this rendering path and gain the same behaviour; both already had working filter code paths, so the chips round-trip correctly.

Verified with `ng build` and the full suite (733 tests passing).