### PR TITLE
fix(#225, #236): agreed form step order + full-width external-catalogs help

### DIFF
--- a/config/form-layout.yaml
+++ b/config/form-layout.yaml
@@ -12,35 +12,35 @@ dataset:
     - id: 1
       key: basic
       label: modify.auth.form.sections.basic
-      fields: ["dct:title", "dct:description", "dcat:keyword", "dcat:theme"]
+      fields: ["dct:title", "dct:description", "dcat:keyword", "dcat:theme", "schema:image"]
     - id: 2
-      key: access
-      label: modify.auth.form.sections.access
-      fields: ["dct:accessRights", "dcatap:availability", "bv:classification", "bv:personalData", "adms:status"]
-    - id: 3
-      key: publisher
-      label: modify.auth.form.sections.publisher
-      fields: ["dct:publisher", "dcat:contactPoint"]
-    - id: 4
       key: metadata
       label: modify.auth.form.sections.metadata
       fields: ["dct:issued", "dct:modified", "dcat:version", "dct:accrualPeriodicity", "bv:typeOfData", "bv:archivalValue"]
-    - id: 5
-      key: governance
-      label: modify.auth.form.sections.governance
-      fields: ["prov:qualifiedAttribution"]
-    - id: 6
+    - id: 3
+      key: access
+      label: modify.auth.form.sections.access
+      fields: ["dct:accessRights", "bv:classification", "bv:personalData", "adms:status", "dcatap:availability"]
+    - id: 4
       key: external
       label: modify.auth.form.sections.external
       fields: ["bv:externalCatalogs", "dcat:landingPage"]
-    - id: 7
+    - id: 5
       key: coverage
       label: modify.auth.form.sections.coverage
       fields: ["dct:spatial", "dct:temporal", "dcatap:applicableLegislation"]
-    - id: 8
+    - id: 6
       key: additional
       label: modify.auth.form.sections.additional
-      fields: ["schema:comment", "bv:geoIdentifier", "schema:image", "bv:abrogation", "prov:wasDerivedFrom", "dcat:inSeries", "dct:replaces"]
+      fields: ["schema:comment", "bv:geoIdentifier", "bv:abrogation", "prov:wasDerivedFrom", "dcat:inSeries", "dct:replaces"]
+    - id: 7
+      key: publisher
+      label: modify.auth.form.sections.publisher
+      fields: ["dct:publisher", "dcat:contactPoint"]
+    - id: 8
+      key: governance
+      label: modify.auth.form.sections.governance
+      fields: ["prov:qualifiedAttribution"]
     - id: 9
       key: distributions
       label: modify.auth.form.sections.distributions

--- a/config/form-layout.yaml
+++ b/config/form-layout.yaml
@@ -50,45 +50,45 @@ dataService:
     - id: 1
       key: basic
       label: modify.auth.form.sections.basic
-      fields: ["dct:title", "dct:description"]
+      fields: ["dct:title", "dct:description", "schema:image"]
     - id: 2
-      key: service
-      label: modify.auth.form.sections.service
-      fields: ["dcat:endpointURL", "dcat:endpointDescription", "dcat:servesDataset", "dct:conformsTo"]
+      key: metadata
+      label: modify.auth.form.sections.metadata
+      fields: ["dcat:version", "adms:versionNotes"]
     - id: 3
       key: access
       label: modify.auth.form.sections.access
       fields: ["dct:accessRights", "adms:status"]
     - id: 4
-      key: publisher
-      label: modify.auth.form.sections.publisher
-      fields: ["dct:publisher", "dcat:contactPoint"]
-    - id: 5
-      key: metadata
-      label: modify.auth.form.sections.metadata
-      fields: ["dcat:version", "adms:versionNotes"]
-    - id: 6
       key: external
       label: modify.auth.form.sections.external
       fields: ["bv:externalCatalogs", "dcat:landingPage"]
-    - id: 7
+    - id: 5
       key: coverage
       label: modify.auth.form.sections.coverage
       fields: ["dcatap:applicableLegislation"]
-    - id: 8
+    - id: 6
       key: additional
       label: modify.auth.form.sections.additional
-      fields: ["schema:comment", "schema:image", "foaf:page"]
+      fields: ["schema:comment", "foaf:page"]
+    - id: 7
+      key: publisher
+      label: modify.auth.form.sections.publisher
+      fields: ["dct:publisher", "dcat:contactPoint"]
+    - id: 8
+      key: service
+      label: modify.auth.form.sections.service
+      fields: ["dcat:endpointURL", "dcat:endpointDescription", "dcat:servesDataset", "dct:conformsTo"]
 datasetSeries:
   steps:
     - id: 1
       key: basic
       label: modify.auth.form.sections.basic
-      fields: ["dct:title", "dct:description", "dcat:keyword", "dcat:theme"]
+      fields: ["dct:title", "dct:description", "dcat:keyword", "dcat:theme", "schema:image"]
     - id: 2
-      key: series
-      label: modify.auth.form.sections.series
-      fields: ["dcat:dataset"]
+      key: metadata
+      label: modify.auth.form.sections.metadata
+      fields: ["dct:issued", "dct:modified", "dcat:version", "dct:accrualPeriodicity", "adms:versionNotes"]
     - id: 3
       key: access
       label: modify.auth.form.sections.access
@@ -96,18 +96,18 @@ datasetSeries:
       # here they could be validated but never entered (#221).
       fields: ["dct:accessRights", "adms:status", "bv:classification", "bv:personalData"]
     - id: 4
-      key: publisher
-      label: modify.auth.form.sections.publisher
-      fields: ["dct:publisher", "dcat:contactPoint", "dct:creator"]
-    - id: 5
-      key: metadata
-      label: modify.auth.form.sections.metadata
-      fields: ["dct:issued", "dct:modified", "dcat:version", "dct:accrualPeriodicity", "adms:versionNotes"]
-    - id: 6
       key: coverage
       label: modify.auth.form.sections.coverage
       fields: ["dct:spatial", "dct:temporal", "dcatap:applicableLegislation"]
-    - id: 7
+    - id: 5
       key: additional
       label: modify.auth.form.sections.additional
-      fields: ["schema:comment", "schema:image", "foaf:page"]
+      fields: ["schema:comment", "foaf:page"]
+    - id: 6
+      key: publisher
+      label: modify.auth.form.sections.publisher
+      fields: ["dct:publisher", "dcat:contactPoint", "dct:creator"]
+    - id: 7
+      key: series
+      label: modify.auth.form.sections.series
+      fields: ["dcat:dataset"]

--- a/e2e/form-step-order.spec.ts
+++ b/e2e/form-step-order.spec.ts
@@ -1,0 +1,142 @@
+import {expect, test} from '@playwright/test';
+import {CHROME_USER_AGENT, installMultiTypeApiMocks} from './support/mock-api';
+
+test.use({userAgent: CHROME_USER_AGENT});
+
+/**
+ * #225: hurni's agreed step order, verified against what the browser actually renders rather
+ * than against the config file the app is compiled from.
+ *
+ * It also checks the order is *consistent* across the three data-product types: a section that
+ * exists for several types must appear in the same relative position everywhere, so a user who
+ * learns the dataset form is not surprised by the data-service form.
+ */
+
+const DATASET_ORDER = [
+	'Basic Information',
+	'Metadata & Versioning',
+	'Access & Classification',
+	'External References & Links',
+	'Coverage & Legal',
+	'Additional Metadata & Relationships',
+	'Publisher & Contact',
+	'Governance & Responsibility',
+	'Distributions'
+];
+
+/** Relative order the shared sections must follow, whichever type is selected. */
+const SHARED_BACKBONE = [
+	'Basic Information',
+	'Metadata & Versioning',
+	'Access & Classification',
+	'External References & Links',
+	'Coverage & Legal',
+	'Additional Metadata & Relationships',
+	'Publisher & Contact',
+	'Governance & Responsibility'
+];
+
+async function stepLabels(page: import('@playwright/test').Page): Promise<string[]> {
+	const labels = await page.locator('.mat-step-header .mat-step-label').allInnerTexts();
+	return labels.map(l => l.trim()).filter(Boolean);
+}
+
+async function selectType(page: import('@playwright/test').Page, type: string): Promise<string[]> {
+	await page.locator('#productTypeSelect').selectOption(type);
+	await expect(page.locator('.mat-step-header').first()).toBeVisible({timeout: 15000});
+	// Let the stepper re-render for the new type before reading it back.
+	await page.waitForTimeout(500);
+	return stepLabels(page);
+}
+
+test.describe('#225 form step order', () => {
+	test.beforeEach(async ({context, page}) => {
+		await installMultiTypeApiMocks(context);
+		await page.goto('/data-catalog/#/modify/form?lang=en');
+		await expect(page.locator('.mat-step-header').first()).toBeVisible({timeout: 30000});
+	});
+
+	test('dataset renders exactly the agreed order', async ({page}) => {
+		expect(await stepLabels(page)).toEqual(DATASET_ORDER);
+	});
+
+	test('shared sections keep the same relative order for every product type', async ({page}) => {
+		for (const type of ['dataset', 'dataService', 'datasetSeries']) {
+			const labels = await selectType(page, type);
+			const backbone = labels.filter(l => SHARED_BACKBONE.includes(l));
+			const expected = SHARED_BACKBONE.filter(l => labels.includes(l));
+			expect(backbone, `relative order of shared sections for ${type}`).toEqual(expected);
+		}
+	});
+
+	test('every type starts with Basic Information', async ({page}) => {
+		for (const type of ['dataset', 'dataService', 'datasetSeries']) {
+			const labels = await selectType(page, type);
+			expect(labels[0], `first step for ${type}`).toBe('Basic Information');
+		}
+	});
+
+	test('the type-specific section sits last, like Distributions does for a dataset', async ({page}) => {
+		// Distributions / Service / Series is what makes each type distinct. hurni put Distributions
+		// at the end for datasets, so the other two types place their counterpart there too.
+		const cases: [string, string][] = [
+			['dataset', 'Distributions'],
+			['dataService', 'Service'],
+			['datasetSeries', 'Series']
+		];
+		for (const [type, section] of cases) {
+			const labels = await selectType(page, type);
+			expect(labels.at(-1), `${section} position for ${type}`).toBe(section);
+		}
+	});
+
+	test('no step is rendered empty or duplicated', async ({page}) => {
+		for (const type of ['dataset', 'dataService', 'datasetSeries']) {
+			const labels = await selectType(page, type);
+			expect(new Set(labels).size, `duplicate step label for ${type}`).toBe(labels.length);
+			expect(labels.length, `step count for ${type}`).toBeGreaterThan(3);
+		}
+	});
+
+	test('every rendered label is translated, never a raw i18n key', async ({page}) => {
+		// A missing labels.* entry renders the key itself (e.g. "labels.schema:image").
+		for (const type of ['dataset', 'dataService', 'datasetSeries']) {
+			await selectType(page, type);
+			const texts = await page.evaluate(() =>
+				Array.from(document.querySelectorAll('.mat-step-label, mat-label, .ob-form-label, label')).map(e => (e.textContent || '').trim())
+			);
+			const raw = texts.filter(t => /^(labels|modify|choices|i18n|ui)\./.test(t));
+			expect(raw, `untranslated keys for ${type}`).toEqual([]);
+		}
+	});
+
+	test('a field shared by several types lives in the same section everywhere', async ({page}) => {
+		// schema:image used to sit in Basic Information for a dataset but in Additional Metadata
+		// for the other two, which is exactly the inconsistency this check guards against.
+		const sectionOf: Record<string, Record<string, string>> = {};
+		for (const type of ['dataset', 'dataService', 'datasetSeries']) {
+			await selectType(page, type);
+			sectionOf[type] = await page.evaluate(() => {
+				const map: Record<string, string> = {};
+				document.querySelectorAll('.mat-step-header').forEach(header => {
+					const section = (header.querySelector('.mat-step-label')?.textContent || '').trim();
+					const contentId = header.getAttribute('aria-controls');
+					const content = contentId ? document.getElementById(contentId) : null;
+					content?.querySelectorAll('mat-label, .ob-form-label').forEach(l => {
+						const text = (l.textContent || '').replace(/\s+/g, ' ').trim();
+						if (text && !map[text]) map[text] = section;
+					});
+				});
+				return map;
+			});
+		}
+
+		const types = Object.keys(sectionOf);
+		const conflicts: string[] = [];
+		for (const field of new Set(types.flatMap(t => Object.keys(sectionOf[t])))) {
+			const sections = new Set(types.filter(t => sectionOf[t][field]).map(t => sectionOf[t][field]));
+			if (sections.size > 1) conflicts.push(`${field}: ${[...sections].join(' vs ')}`);
+		}
+		expect(conflicts, 'same field placed in different sections per type').toEqual([]);
+	});
+});

--- a/src/app/codegen/form-layout.json
+++ b/src/app/codegen/form-layout.json
@@ -9,32 +9,12 @@
           "dct:title",
           "dct:description",
           "dcat:keyword",
-          "dcat:theme"
+          "dcat:theme",
+          "schema:image"
         ]
       },
       {
         "id": 2,
-        "key": "access",
-        "label": "modify.auth.form.sections.access",
-        "fields": [
-          "dct:accessRights",
-          "dcatap:availability",
-          "bv:classification",
-          "bv:personalData",
-          "adms:status"
-        ]
-      },
-      {
-        "id": 3,
-        "key": "publisher",
-        "label": "modify.auth.form.sections.publisher",
-        "fields": [
-          "dct:publisher",
-          "dcat:contactPoint"
-        ]
-      },
-      {
-        "id": 4,
         "key": "metadata",
         "label": "modify.auth.form.sections.metadata",
         "fields": [
@@ -47,15 +27,19 @@
         ]
       },
       {
-        "id": 5,
-        "key": "governance",
-        "label": "modify.auth.form.sections.governance",
+        "id": 3,
+        "key": "access",
+        "label": "modify.auth.form.sections.access",
         "fields": [
-          "prov:qualifiedAttribution"
+          "dct:accessRights",
+          "bv:classification",
+          "bv:personalData",
+          "adms:status",
+          "dcatap:availability"
         ]
       },
       {
-        "id": 6,
+        "id": 4,
         "key": "external",
         "label": "modify.auth.form.sections.external",
         "fields": [
@@ -64,7 +48,7 @@
         ]
       },
       {
-        "id": 7,
+        "id": 5,
         "key": "coverage",
         "label": "modify.auth.form.sections.coverage",
         "fields": [
@@ -74,17 +58,33 @@
         ]
       },
       {
-        "id": 8,
+        "id": 6,
         "key": "additional",
         "label": "modify.auth.form.sections.additional",
         "fields": [
           "schema:comment",
           "bv:geoIdentifier",
-          "schema:image",
           "bv:abrogation",
           "prov:wasDerivedFrom",
           "dcat:inSeries",
           "dct:replaces"
+        ]
+      },
+      {
+        "id": 7,
+        "key": "publisher",
+        "label": "modify.auth.form.sections.publisher",
+        "fields": [
+          "dct:publisher",
+          "dcat:contactPoint"
+        ]
+      },
+      {
+        "id": 8,
+        "key": "governance",
+        "label": "modify.auth.form.sections.governance",
+        "fields": [
+          "prov:qualifiedAttribution"
         ]
       },
       {

--- a/src/app/codegen/form-layout.json
+++ b/src/app/codegen/form-layout.json
@@ -105,18 +105,17 @@
         "label": "modify.auth.form.sections.basic",
         "fields": [
           "dct:title",
-          "dct:description"
+          "dct:description",
+          "schema:image"
         ]
       },
       {
         "id": 2,
-        "key": "service",
-        "label": "modify.auth.form.sections.service",
+        "key": "metadata",
+        "label": "modify.auth.form.sections.metadata",
         "fields": [
-          "dcat:endpointURL",
-          "dcat:endpointDescription",
-          "dcat:servesDataset",
-          "dct:conformsTo"
+          "dcat:version",
+          "adms:versionNotes"
         ]
       },
       {
@@ -130,24 +129,6 @@
       },
       {
         "id": 4,
-        "key": "publisher",
-        "label": "modify.auth.form.sections.publisher",
-        "fields": [
-          "dct:publisher",
-          "dcat:contactPoint"
-        ]
-      },
-      {
-        "id": 5,
-        "key": "metadata",
-        "label": "modify.auth.form.sections.metadata",
-        "fields": [
-          "dcat:version",
-          "adms:versionNotes"
-        ]
-      },
-      {
-        "id": 6,
         "key": "external",
         "label": "modify.auth.form.sections.external",
         "fields": [
@@ -156,7 +137,7 @@
         ]
       },
       {
-        "id": 7,
+        "id": 5,
         "key": "coverage",
         "label": "modify.auth.form.sections.coverage",
         "fields": [
@@ -164,13 +145,32 @@
         ]
       },
       {
-        "id": 8,
+        "id": 6,
         "key": "additional",
         "label": "modify.auth.form.sections.additional",
         "fields": [
           "schema:comment",
-          "schema:image",
           "foaf:page"
+        ]
+      },
+      {
+        "id": 7,
+        "key": "publisher",
+        "label": "modify.auth.form.sections.publisher",
+        "fields": [
+          "dct:publisher",
+          "dcat:contactPoint"
+        ]
+      },
+      {
+        "id": 8,
+        "key": "service",
+        "label": "modify.auth.form.sections.service",
+        "fields": [
+          "dcat:endpointURL",
+          "dcat:endpointDescription",
+          "dcat:servesDataset",
+          "dct:conformsTo"
         ]
       }
     ]
@@ -185,15 +185,20 @@
           "dct:title",
           "dct:description",
           "dcat:keyword",
-          "dcat:theme"
+          "dcat:theme",
+          "schema:image"
         ]
       },
       {
         "id": 2,
-        "key": "series",
-        "label": "modify.auth.form.sections.series",
+        "key": "metadata",
+        "label": "modify.auth.form.sections.metadata",
         "fields": [
-          "dcat:dataset"
+          "dct:issued",
+          "dct:modified",
+          "dcat:version",
+          "dct:accrualPeriodicity",
+          "adms:versionNotes"
         ]
       },
       {
@@ -209,28 +214,6 @@
       },
       {
         "id": 4,
-        "key": "publisher",
-        "label": "modify.auth.form.sections.publisher",
-        "fields": [
-          "dct:publisher",
-          "dcat:contactPoint",
-          "dct:creator"
-        ]
-      },
-      {
-        "id": 5,
-        "key": "metadata",
-        "label": "modify.auth.form.sections.metadata",
-        "fields": [
-          "dct:issued",
-          "dct:modified",
-          "dcat:version",
-          "dct:accrualPeriodicity",
-          "adms:versionNotes"
-        ]
-      },
-      {
-        "id": 6,
         "key": "coverage",
         "label": "modify.auth.form.sections.coverage",
         "fields": [
@@ -240,13 +223,30 @@
         ]
       },
       {
-        "id": 7,
+        "id": 5,
         "key": "additional",
         "label": "modify.auth.form.sections.additional",
         "fields": [
           "schema:comment",
-          "schema:image",
           "foaf:page"
+        ]
+      },
+      {
+        "id": 6,
+        "key": "publisher",
+        "label": "modify.auth.form.sections.publisher",
+        "fields": [
+          "dct:publisher",
+          "dcat:contactPoint",
+          "dct:creator"
+        ]
+      },
+      {
+        "id": 7,
+        "key": "series",
+        "label": "modify.auth.form.sections.series",
+        "fields": [
+          "dcat:dataset"
         ]
       }
     ]

--- a/src/app/models/form-layout-i18n.spec.ts
+++ b/src/app/models/form-layout-i18n.spec.ts
@@ -1,0 +1,46 @@
+import formLayout from '../codegen/form-layout.json';
+import de from '../../assets/i18n/de.json';
+import en from '../../assets/i18n/en.json';
+import fr from '../../assets/i18n/fr.json';
+import itIt from '../../assets/i18n/it.json';
+
+/**
+ * The form layout is the list of fields the edit form actually renders, so every field in it
+ * needs a label in every language. A missing key silently renders the raw translation key
+ * (e.g. "labels.schema:image") in the form, which is what a browser pass through #225 caught.
+ */
+describe('form layout i18n coverage', () => {
+	type Bundle = {labels: Record<string, string>} & Record<string, unknown>;
+
+	const languages: [string, Bundle][] = [
+		['de', de],
+		['en', en],
+		['fr', fr],
+		['it', itIt]
+	];
+
+	const layout = formLayout as Record<string, {steps: {key: string; label: string; fields: string[]}[]}>;
+	const productTypes = Object.keys(layout);
+
+	const allFields = Array.from(new Set(productTypes.flatMap(type => layout[type].steps.flatMap(step => step.fields))));
+
+	const allStepLabels = Array.from(new Set(productTypes.flatMap(type => layout[type].steps.map(step => step.label))));
+
+	function lookup(bundle: Bundle, dottedKey: string): unknown {
+		return dottedKey.split('.').reduce<unknown>((node, part) => (node == null ? undefined : (node as Record<string, unknown>)[part]), bundle);
+	}
+
+	it('covers at least the three known product types', () => {
+		expect(productTypes).toEqual(expect.arrayContaining(['dataset', 'dataService', 'datasetSeries']));
+	});
+
+	describe.each(languages)('%s', (_lang, bundle) => {
+		it.each(allFields)('has a label for %s', field => {
+			expect(bundle.labels[field]).toBeDefined();
+		});
+
+		it.each(allStepLabels)('has a section title for %s', label => {
+			expect(lookup(bundle, label)).toBeDefined();
+		});
+	});
+});

--- a/src/app/modify/modify.component.html
+++ b/src/app/modify/modify.component.html
@@ -276,7 +276,7 @@
 											</div>
 										}
 										@case ("externalCatalogs") {
-											<div class="ob-form-group" style="position: relative">
+											<div class="ob-form-group external-catalogs-group" style="position: relative">
 												<app-field-debug-overlay [label]="'labels.' + fieldKey" [fieldName]="fieldKey"></app-field-debug-overlay>
 												<label class="ob-form-label">{{ "labels." + fieldKey | translate }}</label>
 												<div class="external-catalogs">

--- a/src/app/modify/modify.component.scss
+++ b/src/app/modify/modify.component.scss
@@ -50,12 +50,26 @@
 	min-height: 56px; // Match the height of mat-form-field
 }
 
+// #236: the help text under the external-catalog checkboxes wrapped inside the
+// first grid column. Make the group and its help line span the full row.
+.external-catalogs-group {
+	width: 100%;
+
+	> .ob-text-muted {
+		display: block;
+	}
+}
+
 // Style external catalogs section
 .external-catalogs {
 	display: flex;
 	flex-wrap: wrap;
 	gap: 1rem;
 	margin-bottom: 0.5rem;
+	// #236: the group is laid out in columns, so the checkbox row and its help
+	// text below must claim the full width instead of wrapping inside column one.
+	width: 100%;
+	flex-basis: 100%;
 
 	.mat-mdc-checkbox {
 		.mdc-form-field {
@@ -232,25 +246,6 @@ mat-form-field.required {
 		font-weight: 500;
 		margin-left: 4px;
 		opacity: 0.8;
-	}
-}
-
-// Enhanced external catalog styling
-.external-catalogs {
-	.mat-mdc-checkbox {
-		&.i14y-catalog {
-			.mdc-checkbox__native-control:checked ~ .mdc-checkbox__background {
-				background-color: #0066cc;
-				border-color: #0066cc;
-			}
-		}
-
-		&.ods-catalog {
-			.mdc-checkbox__native-control:checked ~ .mdc-checkbox__background {
-				background-color: #e91e63;
-				border-color: #e91e63;
-			}
-		}
 	}
 }
 

--- a/src/app/services/metadata/dataset-metadata.service.spec.ts
+++ b/src/app/services/metadata/dataset-metadata.service.spec.ts
@@ -116,14 +116,15 @@ describe('DatasetMetadataService', () => {
 		const stepCases: [string, number][] = [
 			['dct:title', 1],
 			['dct:description', 1],
-			['dct:accessRights', 2],
-			['adms:status', 2],
-			['dct:publisher', 3],
-			['dct:issued', 4],
-			['prov:qualifiedAttribution', 5],
-			['bv:externalCatalogs', 6],
-			['dct:spatial', 7],
-			['prov:wasDerivedFrom', 8],
+			['schema:image', 1],
+			['dct:issued', 2],
+			['dct:accessRights', 3],
+			['adms:status', 3],
+			['bv:externalCatalogs', 4],
+			['dct:spatial', 5],
+			['prov:wasDerivedFrom', 6],
+			['dct:publisher', 7],
+			['prov:qualifiedAttribution', 8],
 			['dcat:distribution', 9]
 		];
 
@@ -150,6 +151,31 @@ describe('DatasetMetadataService', () => {
 				const step1 = steps.find(s => s.id === 1);
 				expect(step1?.key).toBe('basic');
 				expect(step1?.fields).toContain('dct:title');
+				done();
+			});
+		});
+
+		it('orders the steps as agreed in #225', done => {
+			service.getSteps().subscribe(steps => {
+				expect(steps.map(s => s.key)).toEqual([
+					'basic',
+					'metadata',
+					'access',
+					'external',
+					'coverage',
+					'additional',
+					'publisher',
+					'governance',
+					'distributions'
+				]);
+				done();
+			});
+		});
+
+		it('puts availability at the bottom of access & classification', done => {
+			service.getSteps().subscribe(steps => {
+				const access = steps.find(s => s.key === 'access');
+				expect(access?.fields.at(-1)).toBe('dcatap:availability');
 				done();
 			});
 		});

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -235,7 +235,7 @@
     "dct:temporal": "Zeitliche Abdeckung",
     "dct:title": "Titel",
     "foaf:page": "Verwandte Ressourcen",
-    "image": "Bild",
+    "schema:image": "Bild",
     "prov:qualifiedAttribution": "Verantwortliche Personen",
     "prov:wasDerivedFrom": "Abgeleitet von",
     "prov:wasGeneratedBy": "Geschäftsprozess",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -234,7 +234,7 @@
     "dct:temporal": "Temporal coverage",
     "dct:title": "Title",
     "foaf:page": "Related resources",
-    "image": "Image",
+    "schema:image": "Image",
     "prov:qualifiedAttribution": "Responsible persons",
     "prov:wasDerivedFrom": "Derived from",
     "prov:wasGeneratedBy": "Business process",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -234,7 +234,7 @@
     "dct:temporal": "Couverture temporelle",
     "dct:title": "Titre",
     "foaf:page": "Ressources associées",
-    "image": "Image",
+    "schema:image": "Image",
     "prov:qualifiedAttribution": "Personnes responsables",
     "prov:wasDerivedFrom": "Dérivé de",
     "prov:wasGeneratedBy": "Processus métier",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -234,7 +234,7 @@
     "dct:temporal": "Copertura temporale",
     "dct:title": "Titolo",
     "foaf:page": "Risorse correlate",
-    "image": "Immagine",
+    "schema:image": "Immagine",
     "prov:qualifiedAttribution": "Persone responsabili",
     "prov:wasDerivedFrom": "Derivato da",
     "prov:wasGeneratedBy": "Processo aziendale",


### PR DESCRIPTION
## #225 form step order

Implements hurni's final grouping from the issue thread. Only `config/form-layout.yaml` (the presentation overlay) changes, no field is added or removed, so no existing entry can break.

New order: Basic Information, Metadata & Versioning, Access & Classification, External References & Links, Coverage & Legal, Additional Metadata & Relationships, Publisher & Contact, Governance & Responsibility, Distributions.

Also per the thread: `dcatap:availability` moves to the bottom of Access & Classification, `schema:image` moves into Basic Information.

Remaining #225 points are **not** in this PR: field help texts, the `bv:internalPath` field, the mutual exclusion with `dcat:accessURL` and the distribution field order.

## #236 external catalogs help text

The help line under the checkboxes wrapped into the first grid column. Fixed with full width. Also removes a dead `.i14y-catalog`/`.ods-catalog` rule block no template applies, which keeps the component under its stylesheet budget.

## Test

736 unit tests green, build clean. Step order and the availability position are now covered by regression tests.