### PR TITLE
fix(#257, #216): alphabetical keywords, additive facet chips with visual feedback

### DIFF
--- a/src/app/index-cards/index-cards.component.spec.ts
+++ b/src/app/index-cards/index-cards.component.spec.ts
@@ -120,10 +120,44 @@ describe('IndexCardsComponent', () => {
 		});
 	});
 
-	it('typeFiltered and publisherFiltered build filter params', () => {
-		expect(component.typeFiltered('dataService')).toEqual({productType: 'dataService'});
-		expect(component.typeFiltered()).toEqual({productType: 'dataset'});
-		expect(component.publisherFiltered('PUB')).toEqual({'dct:publisher': 'PUB'});
+	describe('#216 type and publisher chips', () => {
+		afterEach(() => {
+			routeStub.snapshot.queryParams = {};
+		});
+
+		it('builds filter params for a fresh click', () => {
+			expect(component.typeFiltered('dataService')).toEqual({productType: 'dataService', page: 1});
+			expect(component.typeFiltered()).toEqual({productType: 'dataset', page: 1});
+			expect(component.publisherFiltered('PUB')).toEqual({'dct:publisher': 'PUB', page: 1});
+		});
+
+		it('preserves filters the user already applied', () => {
+			routeStub.snapshot.queryParams = {'dcat:keyword': 'kw1', search: 'milk'};
+			const result = component.typeFiltered('dataset');
+			expect(result['dcat:keyword']).toBe('kw1');
+			expect(result['search']).toBe('milk');
+			expect(result['productType']).toBe('dataset');
+		});
+
+		it('adds the type to an existing productType filter instead of replacing it', () => {
+			routeStub.snapshot.queryParams = {productType: 'dataService'};
+			expect(component.typeFiltered('dataset')['productType']).toBe('dataService,dataset');
+		});
+
+		it('does not duplicate a type that is already filtered', () => {
+			routeStub.snapshot.queryParams = {productType: 'dataset'};
+			expect(component.typeFiltered('dataset')['productType']).toBe('dataset');
+		});
+
+		it('adds the publisher to an existing publisher filter', () => {
+			routeStub.snapshot.queryParams = {'dct:publisher': 'A'};
+			expect(component.publisherFiltered('B')['dct:publisher']).toBe('A,B');
+		});
+
+		it('resets pagination, because the result set changes', () => {
+			routeStub.snapshot.queryParams = {page: 4};
+			expect(component.typeFiltered('dataset')['page']).toBe(1);
+		});
 	});
 
 	describe('keyword expansion', () => {

--- a/src/app/index-cards/index-cards.component.ts
+++ b/src/app/index-cards/index-cards.component.ts
@@ -120,16 +120,17 @@ export class IndexCardsComponent {
 
 	// Filter the index by a product type; used by the type chip so each tile links to its own type
 	// (dataset / dataService / datasetSeries), matching the productType facet (#221).
+	/**
+	 * #216: the chips used to replace every query param, so clicking one silently dropped the
+	 * filters the user had already applied and (for a single-type catalogue) looked like nothing
+	 * happened at all. Merge into the current params instead, additively, like keywordFiltered.
+	 */
 	typeFiltered(type?: string) {
-		return {
-			productType: type || 'dataset'
-		};
+		return this.mergedFacetParams('productType', type || 'dataset');
 	}
 
 	publisherFiltered(publisher: string) {
-		return {
-			'dct:publisher': publisher
-		};
+		return this.mergedFacetParams('dct:publisher', publisher);
 	}
 
 	onChipClick(event: MouseEvent): void {
@@ -250,5 +251,19 @@ export class IndexCardsComponent {
 	 */
 	getChipContainerClass(datasetId: string): string {
 		return this.isExpanded(datasetId) ? 'chip-container expanded' : 'chip-container collapsed';
+	}
+
+	/** Add `value` to the comma-separated facet `key` while preserving the other query params. */
+	private mergedFacetParams(key: string, value: string) {
+		const currentParams = this.route.snapshot.queryParams;
+		const existing = currentParams[key];
+		const already = existing ? existing.split(',') : [];
+
+		return {
+			...currentParams,
+			[key]: already.includes(value) ? existing : [...already, value].join(','),
+			// A changed filter set invalidates the current page offset (#216).
+			page: 1
+		};
 	}
 }

--- a/src/app/index-switch/index-switch.component.html
+++ b/src/app/index-switch/index-switch.component.html
@@ -43,7 +43,7 @@
 				obButton="secondary"
 				type="button"
 			>
-				<mat-icon svgIcon="filter" />
+				<mat-icon svgIcon="filter" [matBadge]="activeFilterCount" [matBadgeHidden]="activeFilterCount === 0" matBadgeSize="small" matBadgeColor="accent" />
 				@if (showFilters) {
 					{{ "ui.hideFilters" | translate }}
 				} @else {

--- a/src/app/index-switch/index-switch.component.spec.ts
+++ b/src/app/index-switch/index-switch.component.spec.ts
@@ -71,6 +71,32 @@ describe('IndexSwitchComponent', () => {
 		});
 	});
 
+	describe('#216 active-filter badge', () => {
+		it('is zero when no filter is applied', () => {
+			queryParams.next({view: 'tile'});
+			fixture.detectChanges();
+			expect(component.activeFilterCount).toBe(0);
+		});
+
+		it('counts a single applied facet value', () => {
+			queryParams.next({productType: 'dataset'});
+			fixture.detectChanges();
+			expect(component.activeFilterCount).toBe(1);
+		});
+
+		it('counts every value across all facets', () => {
+			queryParams.next({productType: 'dataset,dataService', 'dcat:keyword': 'kw1'});
+			fixture.detectChanges();
+			expect(component.activeFilterCount).toBe(3);
+		});
+
+		it('ignores non-facet params like search and pagination', () => {
+			queryParams.next({search: 'milk', page: 2, view: 'table'});
+			fixture.detectChanges();
+			expect(component.activeFilterCount).toBe(0);
+		});
+	});
+
 	describe('view switching', () => {
 		it('switchTo navigates with the view query param merged', async () => {
 			const router = TestBed.inject(Router);

--- a/src/app/index-switch/index-switch.component.ts
+++ b/src/app/index-switch/index-switch.component.ts
@@ -49,6 +49,11 @@ import {TranslatePipe} from '@ngx-translate/core';
 export class IndexSwitchComponent implements OnInit, OnDestroy, AfterViewInit {
 	view: 'table' | 'tile' = 'tile';
 	showFilters = false;
+	/**
+	 * #216: clicking a facet chip gave no feedback that a filter had been applied, especially with
+	 * the filter panel collapsed. Surface the number of active facet values on the filter button.
+	 */
+	activeFilterCount = 0;
 	@Input() datasets$: Observable<DataProduct[] | null> = new Observable();
 	activatedFilters$: BehaviorSubject<ActiveFilters> = new BehaviorSubject({});
 	@ViewChild(MatSelect) sortSelect!: MatSelect;
@@ -76,6 +81,7 @@ export class IndexSwitchComponent implements OnInit, OnDestroy, AfterViewInit {
 			// Parse and populate filter state from URL parameters
 			const urlFilters = createActiveFiltersFromParams(params);
 			this.activatedFilters$.next(urlFilters);
+			this.activeFilterCount = this.countActiveFilters(urlFilters);
 
 			// Apply filters to the dataset service regardless of filter panel visibility
 			await this.datasetService.setFilters(urlFilters);
@@ -185,5 +191,10 @@ export class IndexSwitchComponent implements OnInit, OnDestroy, AfterViewInit {
 				mode: 'new'
 			}
 		});
+	}
+
+	/** #216: total number of selected values across all facets. */
+	private countActiveFilters(filters: ActiveFilters): number {
+		return Object.values(filters).reduce((total, subfilters) => total + Object.values(subfilters).filter(Boolean).length, 0);
 	}
 }

--- a/src/app/modify/form/components/keyword-select-field/keyword-select-field.component.spec.ts
+++ b/src/app/modify/form/components/keyword-select-field/keyword-select-field.component.spec.ts
@@ -50,6 +50,45 @@ describe('KeywordSelectFieldComponent', () => {
 		expect(component.keywords[0].code).toBe('kw-a');
 	});
 
+	describe('#257 alphabetical order', () => {
+		const unsorted: Keyword[] = [
+			{code: 'kw-z', labels: {de: 'Zucker', fr: 'Sucre', it: 'Zucchero', en: 'Sugar'}},
+			{code: 'kw-a', labels: {de: 'Apfel', fr: 'Pomme', it: 'Mela', en: 'Apple'}},
+			{code: 'kw-m', labels: {de: 'Milch', fr: 'Lait', it: 'Latte', en: 'Milk'}}
+		];
+
+		it('sorts the options by their label in the active language', () => {
+			setup(unsorted);
+			fixture.detectChanges();
+			expect(component.keywords.map(k => k.labels.de)).toEqual(['Apfel', 'Milch', 'Zucker']);
+		});
+
+		it('sorts by the French label when French is active', () => {
+			const keywordServiceStub = stubKeywordService(unsorted, {keywords$: of(unsorted)});
+			TestBed.configureTestingModule({
+				imports: [KeywordSelectFieldComponent, NoopAnimationsModule, provideTranslateTesting()],
+				providers: [
+					{provide: ValidationSchemaService, useValue: stubValidationSchemaService()},
+					{provide: KeywordService, useValue: keywordServiceStub},
+					{provide: TranslateService, useValue: stubTranslateService({currentLang: 'fr'})}
+				]
+			});
+			const frFixture = TestBed.createComponent(KeywordSelectFieldComponent);
+			frFixture.detectChanges();
+			// Lait, Pomme, Sucre
+			expect(frFixture.componentInstance.keywords.map(k => k.code)).toEqual(['kw-m', 'kw-a', 'kw-z']);
+		});
+
+		it('ignores case and diacritics when ordering', () => {
+			setup([
+				{code: 'b', labels: {de: 'Ähre', fr: 'a', it: 'a', en: 'a'}},
+				{code: 'a', labels: {de: 'apfel', fr: 'b', it: 'b', en: 'b'}}
+			]);
+			fixture.detectChanges();
+			expect(component.keywords.map(k => k.labels.de)).toEqual(['Ähre', 'apfel']);
+		});
+	});
+
 	describe('writeValue', () => {
 		it('accepts an array of codes', () => {
 			setup();

--- a/src/app/modify/form/components/keyword-select-field/keyword-select-field.component.ts
+++ b/src/app/modify/form/components/keyword-select-field/keyword-select-field.component.ts
@@ -103,7 +103,13 @@ export class KeywordSelectFieldComponent implements ControlValueAccessor, OnInit
 
 		// Subscribe to keyword changes from KeywordService
 		this.keywordService.keywords$.pipe(takeUntil(this.destroy$)).subscribe(keywords => {
-			this.keywords = keywords;
+			this.keywords = this.sortByLabel(keywords);
+		});
+
+		// #257: labels differ per language, so the dropdown has to be re-sorted
+		// whenever the user switches language.
+		this.translateService.onLangChange.pipe(takeUntil(this.destroy$)).subscribe(() => {
+			this.keywords = this.sortByLabel(this.keywords);
 		});
 
 		// Load keywords if not already loaded
@@ -184,5 +190,11 @@ export class KeywordSelectFieldComponent implements ControlValueAccessor, OnInit
 
 		// Join with comma and space
 		return selectedLabels.join(', ');
+	}
+
+	/** #257: alphabetical order in the dropdown, by the label shown in the active language. */
+	private sortByLabel(keywords: Keyword[]): Keyword[] {
+		const lang = this.translateService.currentLang || 'de';
+		return [...keywords].sort((a, b) => this.getKeywordLabel(a).localeCompare(this.getKeywordLabel(b), lang, {sensitivity: 'base'}));
 	}
 }


### PR DESCRIPTION
## #257 keywords alphabetical

The keyword dropdown listed the vocabulary in fetch order. It now sorts by the label of the active language, using `localeCompare` so umlauts and case sort naturally, and re-sorts when the user switches language.

## #216 dataset chip in tile view

Root cause: `typeFiltered()` and `publisherFiltered()` returned a fresh params object, so `routerLink` replaced the whole query string. Clicking a chip therefore dropped the filters the user had already applied, and since the catalogue currently holds only datasets, filtering to `productType=dataset` changed nothing visible. That is exactly the reported "nothing happens, and my filters are gone".

Both now behave like `keywordFiltered()`: merge into the current params and add the value to the comma-separated facet, without duplicating, plus reset `page` since the result set changes.

For the requested visual indication, the filter button carries a badge with the number of active facet values, which also helps when the filter panel is collapsed.

## Test

745 unit tests green (13 new), build clean, no new lint findings (973 before and after). The #257 sort tests were confirmed to fail without the fix.